### PR TITLE
allow instanceOf(class { private constuctor() })

### DIFF
--- a/lib/checks/instance-of.ts
+++ b/lib/checks/instance-of.ts
@@ -1,9 +1,7 @@
 import { Err, Result } from "../result";
 import { Type } from "../type";
 
-interface Constructor<T> {
-  new (...args: Array<any>): T;
-}
+type Constructor<T> = Function & { prototype: T }
 
 export class InstanceOf<T> extends Type<T> {
   private klass: Constructor<T>;


### PR DESCRIPTION
Although the type is a little less pretty, this check allows us to circumvent this error if the constructor is marked "private":

> Cannot assign a 'private' constructor type to a 'public' constructor type.

I used this solution from Stack Overflow: https://stackoverflow.com/a/38642922/379439