### PR TITLE
add t.is(typeName: string, guard: (v: any) => v is T)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ export * from "./lib/checks/map";
 export * from "./lib/checks/set";
 export * from "./lib/checks/primitives";
 export * from "./lib/checks/any";
+export * from "./lib/checks/is";
 
 export * from "./lib/kind";
 

--- a/lib/checks/is.ts
+++ b/lib/checks/is.ts
@@ -1,0 +1,24 @@
+import { Err, Result } from "../result";
+import { Type } from "../type";
+
+type Guard<T> = (val: any) => val is T
+
+export class Is<T> extends Type<T> {
+  readonly name: string
+  readonly isT: Guard<T>
+
+  constructor(name: string, guard: Guard<T>) {
+    super()
+    this.name = name
+    this.isT = guard
+  }
+
+  check(val: any): Result<T> {
+    if(this.isT(val)) return val;
+    return new Err(`${val} is not a ${this.name} (guard failed)`)
+  }
+}
+
+export function is<T>(name: string, guard: Guard<T>) {
+  return new Is<T>(name, guard)
+}

--- a/lib/kind.ts
+++ b/lib/kind.ts
@@ -8,6 +8,7 @@ import { Dict } from "./checks/dict";
 import { MapType } from "./checks/map";
 import { SetType } from "./checks/set";
 import { Any } from "./checks/any";
+import { Is } from "./checks/is";
 
 export type Kind = Any
                  | SetType<any>
@@ -21,4 +22,5 @@ export type Kind = Any
                  | Either<any, any>
                  | Intersect<any, any>
                  | Validation<any>
+                 | Is<any>
                  ;

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -11,6 +11,20 @@ export abstract class Type<T> {
     return assert(this.sliceResult(val));
   }
 
+  /**
+   * Use as a type guard.
+   *
+   * @example
+   *   const FooChecker: t.Type<T> = ...
+   *   if (FooChecker.guard(val)) {
+   *     // in this scope, val has type T
+   *   }
+   */
+  guard(val: any): val is T {
+    const result = this.sliceResult(val);
+    return !(result instanceof Err)
+  }
+
   /*
    * Default slice implementation just calls `check`. Override this as necessary.
    */

--- a/test/is.ts
+++ b/test/is.ts
@@ -1,0 +1,33 @@
+import * as t from "..";
+
+test("passes when the fn returns true", () => {
+  const check = t.is('string', (val: any): val is string => typeof val === 'string')
+  check.assert('foo');
+})
+
+test("fails when the fn returns false", () => {
+  const check = t.is('numba', (val: any): val is number => typeof val === 'number')
+  expect(() => {
+    check.assert('not a numba??')
+  }).toThrow();
+})
+
+test("works as a guard w/ type inference", () => {
+  class Doggo {
+    bark() { return true }
+  }
+  function maybeDoggo(): Doggo | string {
+    return new Doggo()
+  }
+  const check = t.is("a doggo", (val: any): val is Doggo => val instanceof Doggo)
+  const yolo = maybeDoggo()
+  // if uncommented, this *SHOULD* fail to compile
+  // yolo.bark()
+
+  let success = false
+  if (check.guard(yolo)) {
+    success = yolo.bark()
+  }
+
+  expect(success).toBe(true)
+})

--- a/test/kind.ts
+++ b/test/kind.ts
@@ -44,6 +44,9 @@ test("allows type narrowing for exhaustiveness checking", () => {
     if(u instanceof t.Intersect) {
       return "intersect";
     }
+    if(u instanceof t.Is) {
+      return "is"
+    }
 
     // This should compile even though we never ran `if(u instanceof Validation)`, because we've
     // narrowed the type to just Validation by checking for everything else that `Kind` could be.


### PR DESCRIPTION
I have some types in my project that can't actually exist "in real life" that I use to wrap a non-generic type with additional type hinting:

```typescript
export type ServerTimestamp = 'serverTimestamp' & firestore.FieldValue;
export type Delete = 'delete' & firestore.FieldValue;
export type ArrayUnion<T> = 'arrayUnion' & T & firestore.FieldValue;
export type ArrayRemove<T> = 'arrayRemove' & T & firestore.FieldValue;
```

To allow structural to validate that some value is specifically a ServerTimestamp, I can write a type guard like so:

```typescript
const canonicalTS = firestore.FeildValue.serverTimestamp() as ServerTimestamp
function isServerTimestamp(val: any): val is ServerTimestamp {
  return (val instanceof firestore.FieldValue) && canonicalTS.isEqual(val)
}
```

So, I need a way to use guards in the `structural` type assertion system that works with the rest of the structural type inference biz.