### PR TITLE
Add t.never

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ export * from "./lib/checks/set";
 export * from "./lib/checks/primitives";
 export * from "./lib/checks/any";
 export * from "./lib/checks/is";
+export * from "./lib/checks/never";
 
 export * from "./lib/kind";
 

--- a/lib/checks/never.ts
+++ b/lib/checks/never.ts
@@ -2,7 +2,7 @@ import { Result, Err } from "../result";
 import { Type } from "../type";
 
 export class Never extends Type<never> {
-  check(val: any): Result<never> {
+  check(_: any): Result<never> {
     return new Err('never')
   }
 }

--- a/lib/checks/never.ts
+++ b/lib/checks/never.ts
@@ -1,0 +1,10 @@
+import { Result, Err } from "../result";
+import { Type } from "../type";
+
+export class Never extends Type<never> {
+  check(val: any): Result<never> {
+    return new Err('never')
+  }
+}
+
+export const never = new Never();

--- a/lib/kind.ts
+++ b/lib/kind.ts
@@ -9,8 +9,10 @@ import { MapType } from "./checks/map";
 import { SetType } from "./checks/set";
 import { Any } from "./checks/any";
 import { Is } from "./checks/is";
+import { Never } from "./checks/never";
 
 export type Kind = Any
+                 | Never
                  | SetType<any>
                  | MapType<any, any>
                  | Dict<any>

--- a/test/kind.ts
+++ b/test/kind.ts
@@ -47,6 +47,9 @@ test("allows type narrowing for exhaustiveness checking", () => {
     if(u instanceof t.Is) {
       return "is"
     }
+    if (u instanceof t.Never) {
+      return "never"
+    }
 
     // This should compile even though we never ran `if(u instanceof Validation)`, because we've
     // narrowed the type to just Validation by checking for everything else that `Kind` could be.

--- a/test/never.ts
+++ b/test/never.ts
@@ -1,0 +1,14 @@
+import * as t from "..";
+
+// what a test.
+test("accepts nothing", () => {
+  expect(() => {
+    t.never.assert(5);
+  }).toThrow();
+  expect(() => {
+    t.never.assert("five");
+  }).toThrow();
+  expect(() => {
+    t.never.assert({});
+  }).toThrow();
+});


### PR DESCRIPTION
This is missing. I don't have a super-convincing use-case, but I did end up with some never types in my code, so maybe worth including?

```typescript
// This might not be the best way of achieving my goals...

// This is the current (at v5.6.0) internal structure of a firebase.firestore.FieldValue.
interface IPrivateFieldValue<Op, El=never> {
  _method: Op,
  _elements: El[],
}

// no children
export type Delete = firestore.FieldValue & IPrivateFieldValue<'FieldValue.delete'>;
// children
export type ArrayUnion<T> = firestore.FieldValue & IPrivateFieldValue<'FieldValue.arrayUnion', T>;

// such soup
const DeleteChecker: t.Type<updates.Delete> =
  FieldValueChecker.and(t.subtype({ _method: t.value('FieldValue.delete' as 'FieldValue.delete'), _elements: t.array(t.never) }))
const arrayUnionCheckerOf = <T>(checker: t.Type<T>): t.Type<updates.ArrayUnion<T>> =>
  FieldValueChecker.and(t.subtype({ _method: t.value('FieldValue.arrayUnion' as 'FieldValue.arrayUnion'), _elements: t.array(checker) }))


```