### PR TITLE
t.match, t.when: write type switches with structural

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 export * from "./lib/result";
 export * from "./lib/type";
 export * from "./lib/get-type";
+export * from "./lib/match"
 
 export * from "./lib/checks/type-of";
 export * from "./lib/checks/instance-of";

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -1,0 +1,108 @@
+import { Type } from './type'
+
+type MapFn<In, Out> = (x: In) => Out
+
+class Case<In, Out> {
+  type: Type<In>
+  fn: (x: In) => Out
+
+  constructor(type: Type<In>, fn: (x: In) => Out) {
+    this.type = type
+    this.fn = fn
+  }
+}
+
+type InOfCase<T extends Case<any, any>> = T extends Case<infer In, any> ?
+  In : never
+
+type OutOfCase<T extends Case<any, any>> = T extends Case<any, infer Out> ?
+  Out : never
+
+export class CaseSwitch<Cases extends Case<any, any>> {
+  cases: Cases[]
+  private memoAccept: Type<InOfCase<Cases>> | undefined
+
+  constructor(cases: Cases[]) {
+    if (cases.length === 0) {
+      throw new Error("must have at least one ase")
+    }
+    this.cases = cases
+  }
+
+  // implemented lazily because not every CaseSwitch will be used
+  get accept(): Type<InOfCase<Cases>> {
+    if (this.memoAccept) {
+      return this.memoAccept
+    }
+    const cases = this.cases
+    let type = cases[0].type
+    for (let i = 1; i < cases.length; i++) {
+      type = type.or(cases[i].type)
+    }
+    this.memoAccept = type
+    return this.memoAccept
+  }
+
+  run(val: InOfCase<Cases>): OutOfCase<Cases> {
+    for (let c of this.cases) {
+      if (c.type.guard(val)) {
+        return c.fn(val)
+      }
+    }
+    this.accept.assert(val)
+    throw "unreachable"
+  }
+
+  /**
+   * create a new CaseSwitch that also handles the specified case.
+   */
+  when<In, Out>(type: Type<In>, fn: (v: In) => Out): CaseSwitch<Cases | Case<In, Out>> {
+    const c = new Case(type, fn)
+    return new CaseSwitch([...this.cases, c])
+  }
+}
+
+export class Switch<In, Out, Func extends MapFn<any,any>> {
+  accept: Type<In>
+  arms: Map<Type<In>, Func>
+
+  constructor(type: Type<In>, arms?: Map<Type<In>, Func>) {
+    this.accept = type
+    this.arms = arms ? new Map(arms) : new Map()
+  }
+
+  when<NewIn, NewOut>(type: Type<NewIn>, fn: MapFn<NewIn, NewOut>): Switch<In|NewIn, Out|NewOut, Func|MapFn<NewIn, NewOut>> {
+    const result = new Switch<In |NewIn, Out|NewOut, Func|MapFn<NewIn, NewOut>>(this.accept.or(type), this.arms)
+    result.arms.set(type, fn)
+    return result
+  }
+
+  run(val: In): Out {
+    for (const [type, fn] of this.arms) {
+      if (type.guard(val)) {
+        return fn(val)
+      }
+    }
+    // for JS when types are not guaranteed
+    this.accept.assert(val)
+    throw new Error("unreachable")
+  }
+}
+
+export function when<In, Out>(type: Type<In>, fn: MapFn<In, Out>) {
+  const c = new Case(type, fn)
+  return new CaseSwitch([c])
+}
+
+/**
+ * Usage:
+ *
+ * const asString = t.match(foo,
+ *   t.when(t.array(t.string), xs => xs.join(' and '))
+ *    .when(t.string,           s => s))
+ *    .when(t.any,              x => '' + x))
+ */
+// export function match<I, O, Cases extends Case<I, O>>(val: I, cases: CaseSwitch<Cases>): O {
+export function match<Cases extends Case<any, any>>(val: InOfCase<Cases>, sw: CaseSwitch<Cases>): OutOfCase<Cases> {
+  return sw.run(val)
+}

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -44,13 +44,12 @@ export class CaseSwitch<Cases extends Case<any, any>> {
   run(val: InOfCase<Cases>): OutOfCase<Cases> {
     for (let c of this.cases) {
       if (c.type.guard(val)) {
-        return c.fn(val)
+        return c.fn(val);
       }
     }
     // raise a type error if none of the cases match the value.
-    this.accept.assert(val)
-    // satisfy return value checking
-    throw "unreachable"
+    this.accept.assert(val);
+    /* istanbul ignore next */ throw "unreachable";
   }
 
   /**

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -74,9 +74,9 @@ export function when<In, Out>(type: Type<In>, fn: (v: In) => Out) {
  *
  * @example
  * const asString = t.match(foo,
- *   t.when(t.array(t.string), xs => xs.join(' and '))
- *    .when(t.string,           s => s))
- *    .when(t.any,              x => '' + x))
+ *   t.when(t.array(t.str), xs => xs.join(' and '))
+ *    .when(t.str,           s => s)
+ *    .when(t.any,           x => '' + x))
  */
 // export function match<I, O, Cases extends Case<I, O>>(val: I, cases: CaseSwitch<Cases>): O {
 export function match<Cases extends Case<any, any>>(val: InOfCase<Cases>, sw: CaseSwitch<Cases>): OutOfCase<Cases> {

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -22,7 +22,7 @@ export class CaseSwitch<Cases extends Case<any, any>> {
 
   constructor(cases: Cases[]) {
     if (cases.length === 0) {
-      throw new Error("must have at least one ase")
+      throw new Error("must have at least one case")
     }
     this.cases = cases
   }

--- a/test/match.ts
+++ b/test/match.ts
@@ -1,0 +1,29 @@
+import * as t from ".."
+
+test("returns value", () => {
+  expect(
+    t.match(
+      5, t.when(t.str, x => `hello ${x}`)
+          .when(t.num, x => x * 2))
+  ).toBe(10)
+})
+
+test("enforces exhaustive match", () => {
+  const handle = (x: number | string) => {
+    // strange:
+    // :TSDoc on matcher shows this type:
+    // const matcher: t.Switch<number, number, MapFn<number, number> | MapFn<5, number>>
+    const matcher = t.when(t.num, (x: number) => x * x)
+      .when(t.value(5 as 5), (x: 5) => x + 1)
+      .when(t.str, x => x.length)
+    // :TSDoc on t.match shows these types inferred:
+    //  function match<string | number, number, MapFn<number, number> | MapFn<5, number>>(val: string | number, cases: t.Switch<string | number, number, MapFn<number, number> | MapFn<5, number>>): number
+    // How can the cases: value be accept `matcher` if matcher has type
+    // Switch<In=number, ...> but cases needs Switch<In=number|string, ...> ??
+    //
+    // matcher.run(x) also fails to compile... so why does t.match(x, matcher) work?
+    // return matcher.run(x)
+    return t.match(x, matcher)
+  }
+  handle('foo')
+})

--- a/test/match.ts
+++ b/test/match.ts
@@ -1,5 +1,19 @@
 import * as t from ".."
 
+describe(t.CaseSwitch, () => {
+  test("cannot construct with zero cases", () => {
+    expect(() => {
+      new t.CaseSwitch([])
+    }).toThrow()
+  })
+
+  test("type acceptance is memoized", () => {
+    const matcher = t.when(t.str, () => 'str')
+                     .when(t.num, () => 'num')
+    expect(matcher.accept).toBe(matcher.accept)
+  })
+})
+
 test("returns value", () => {
   expect(
     t.match(


### PR DESCRIPTION
t.when is a function composition construct that returns a `CaseSwitch` object parameterized with the types of each "case" arm.
```typescript
  const matcher = t.when(t.str, x => `hello ${x}`)
                   .when(t.instanceOf(Dog), _ => 'dog')
                   .when(t.instanceOf(Animal), _ => 'animal')
  // type: t.CaseSwitch<Case<string, string> | Case<Dog, string> | Case<Animal, string>>
```

t.match is  syntactic sugar that calls the `run()` method of a CaseSwitch object. It exists so that it's possible to use a `t.match(...)` with syntax that resembles a `switch` or `case` expression in programming languages; where the "object under test" appears at the beginning:
```typescript
const asString = t.match(foo,
  t.when(t.array(t.str), xs => xs.join(' and '))
   .when(t.str,           s => s)
   .when(t.any,           x => '' + x))
```

If used from Javascript or with unsound `any` casts, `t.match` will throw at runtime if none of the arms matched:

```typescript
// matcher = ... from the first example
t.match(5 as any, matcher)
// 5 failed the following checks:
//     5 failed the following checks:
//     5 is not a string
//     5 is not an instance of class Dog extends Animal {
//         }
//     5 is not an instance of class Animal {
//         }
```

`t.match` and `t.when` are especially handy when working with algebraic type inputs because the compiler will warn if there is no `.when(...)` arm for a type. For example, here's an exhaustive match for `Kind`:

```typescript
const fn = (u: t.Kind) => t.match(u,
    t.when(t.instanceOf(t.Any), () => 'any')
     // comment out any arm, and compilation will fail.
     .when(t.instanceOf(t.Never), () => 'never')
     .when(t.instanceOf(t.SetType), () => 'set')
     .when(t.instanceOf(t.MapType), () => 'map')
     .when(t.instanceOf(t.Dict), () => 'dict')
     .when(t.instanceOf(t.Struct), () => 'struct')
     .when(t.instanceOf(t.Arr), () => 'array')
     .when(t.instanceOf(t.Value), () => 'value')
     .when(t.instanceOf(t.InstanceOf), () => 'instanceof')
     .when(t.instanceOf(t.TypeOf), () => 'typeof')
     .when(t.instanceOf(t.Either), () => 'either')
     .when(t.instanceOf(t.Intersect), () => 'intersect')
     .when(t.instanceOf(t.Validation), () => 'validation')
     .when(t.instanceOf(t.Is), () => 'is'))
```