### PR TITLE
Teach t.subtyppe and t.exact about optional (foo?:) keys

### DIFF
--- a/lib/checks/primitives.ts
+++ b/lib/checks/primitives.ts
@@ -14,7 +14,3 @@ export const obj = typeOf<Object>('object');
 export function maybe<T>(check: Type<T>): Type<T|null> {
   return check.or(nil);
 }
-
-export function optional<T>(check: Type<T>): Type<T|undefined> {
-  return check.or(undef);
-}

--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -6,7 +6,7 @@ import { GetType } from "../get-type";
  * OptionalKey is a marker type that indicates that the key in a struct that
  * holds an OptionalKey is optional.
  */
-class OptionalKey<T extends Type<any>> {
+export class OptionalKey<T extends Type<any>> {
   type: T
 
   constructor(type: T) {

--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -2,13 +2,51 @@ import { Err } from "../result";
 import { KeyTrackResult, Type, KeyTrackingType } from "../type";
 import { GetType } from "../get-type";
 
+/**
+ * OptionalKey is a marker type that indicates that the key in a struct that
+ * holds an OptionalKey is optional.
+ */
+class OptionalKey<T extends Type<any>> {
+  type: T
+
+  constructor(type: T) {
+    this.type = type
+  }
+}
+
+type OptionalOrType<T> = T extends OptionalKey<infer Inner> ? Inner : T
+
 type TypeStruct = {
-  [key: string]: Type<any>;
+  [key: string]: Type<any> | OptionalKey<any>;
 };
 
-type UnwrappedTypeStruct<T extends TypeStruct> = {
-  [P in keyof T]: GetType<T[P]>;
-};
+// see this blog post for an explanation of this type shenanigans
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+
+// Returns a type like `"foo" | "bar"` for all the optional keys in a typestruct
+type OptionalPropertyNames<T extends TypeStruct> = {
+  [K in keyof T]: T[K] extends OptionalKey<any> ? K : never
+}[keyof T]
+
+// Unwraps Type<T> and OptionalKey<Type<T>> to T for all keys in a typestruct
+type UnwrapTypes<T extends TypeStruct> = {
+  [K in keyof T]: GetType<OptionalOrType<T[K]>>
+}
+
+export type UnwrappedTypeStruct<T extends TypeStruct> =
+  /* required props */ Pick<UnwrapTypes<T>, Exclude<keyof T, OptionalPropertyNames<T>>> &
+  /* optional props */ Partial<Pick<UnwrapTypes<T>, OptionalPropertyNames<T>>>
+
+export function keyType<T>(box: OptionalKey<Type<T>> | Type<T>): Type<T> {
+  if (box instanceof OptionalKey) {
+    return box.type;
+  }
+  return box;
+}
+
+export function isOptional<T extends Type<any>>(box: OptionalKey<T> | T): box is OptionalKey<T> {
+  return (box instanceof OptionalKey)
+}
 
 export class Struct<T extends TypeStruct> extends KeyTrackingType<UnwrappedTypeStruct<T>> {
   readonly definition: T;
@@ -47,7 +85,17 @@ export class Struct<T extends TypeStruct> extends KeyTrackingType<UnwrappedTypeS
   private checkFields(val: any): string[] {
     const errs: string[] = [];
     for(const prop in this.definition) {
-      const result = this.definition[prop].check(val[prop]);
+      const field = this.definition[prop]
+      if (!(prop in val)) {
+        if (isOptional(field)) {
+          continue;
+        }
+
+        errs.push(`missing key '${prop}'`)
+        continue;
+      }
+
+      const result = keyType(field).check(val[prop]);
       if(result instanceof Err) errs.push(result.message);
     }
 
@@ -63,4 +111,8 @@ export function subtype<T extends TypeStruct>(def: T): HiddenStruct<T> {
 
 export function exact<T extends TypeStruct>(def: T): HiddenStruct<T> {
   return new Struct(def, true);
+}
+
+export function optional<T extends Type<any>>(check: T): OptionalKey<T> {
+  return new OptionalKey(check)
 }

--- a/lib/get-type.ts
+++ b/lib/get-type.ts
@@ -1,6 +1,7 @@
 import { Type } from "./type";
 
 type GenericFn<T, R extends Type<T>> = (...a: any[]) => R;
-export type GetType<T> = T extends Type<infer U> ? U :
+
+export type GetType<T extends Type<any>> = T extends Type<infer U> ? U :
                          (T extends GenericFn<any, infer R> ?
                            (R extends Type<infer U> ? U : never) : never);

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -25,6 +25,18 @@ export abstract class Type<T> {
     return !(result instanceof Err)
   }
 
+  /**
+   * Typescript helper that enforces the correct declaration of a value with no
+   * overhead.
+   *
+   * @example
+   * const User = t.subtype({ name: t.str, email: t.str })
+   * const myUser = User.({ dog: 'cow' }) // Typescript compile error
+   */
+  t(val: T): T {
+    return val
+  }
+
   /*
    * Default slice implementation just calls `check`. Override this as necessary.
    */

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -155,7 +155,12 @@ export abstract class KeyTrackingType<T> extends Type<T> {
     // just the known set of keys.
     const sliced: { [key: string]: any } = {};
     for(const key of result.knownKeys) {
-      sliced[key] = val[key];
+      // only copy keys that exist.
+      // our type-checking already disallows {} fitting { foo: t.undef }
+      // because foo is missing, so this can't produce invalid results.
+      if (key in val) {
+        sliced[key] = val[key];
+      }
     }
 
     return sliced as T;

--- a/test/primitives.ts
+++ b/test/primitives.ts
@@ -120,31 +120,3 @@ describe("maybe", () => {
     }).toThrow();
   });
 });
-
-describe("optional", () => {
-  test("accepts the matching value", () => {
-    const check = t.optional(t.num);
-    check.assert(5);
-  });
-
-  test("accepts undefined", () => {
-    const check = t.optional(t.num);
-    check.assert(undefined);
-  });
-
-  test("rejects non-matching values", () => {
-    const check = t.optional(t.num);
-    expect(() => {
-      check.assert(true);
-    }).toThrow();
-  });
-
-  test("allows partial definition in structs", () => {
-    const check = t.subtype({
-      hi: t.optional(t.str),
-      foo: t.str,
-    });
-
-    check.assert({ foo: "bar" });
-  });
-});

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -48,6 +48,15 @@ describe("subtype", () => {
     check.assert(wat)
   })
 
+  test("type inference allows omitting optional keys with .t", () => {
+    const check = t.subtype({
+      email: t.str,
+      name: t.optional(t.str),
+    })
+
+    check.t({ email: 'bob@example.com' })
+  })
+
   test("rejects subtypes", () => {
     const check = t.subtype({
       hi: t.str,

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -15,6 +15,39 @@ describe("subtype", () => {
     check.assert({ hi: "world", foo: "bar" });
   });
 
+  test("allows optional keys to be missing", () => {
+    const check = t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    })
+    check.assert({ hi: "world" })
+  })
+
+  test("rejects optional keys that exist, but are undefined", () => {
+    const check = t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    })
+    expect(() => {
+      check.assert({ hi: "world", opt: undefined })
+    }).toThrow()
+  })
+
+  test("type inference allows omitting optional keys", () => {
+    const check = t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    })
+
+    type Derpus = t.GetType<typeof check>
+
+    const wat: Derpus = {
+      hi: 'dog',
+    }
+
+    check.assert(wat)
+  })
+
   test("rejects subtypes", () => {
     const check = t.subtype({
       hi: t.str,
@@ -64,6 +97,24 @@ describe("exact", () => {
     });
     check.assert({ hi: "world" });
   });
+
+  test("allows optional keys to be missing", () => {
+    const check = t.exact({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    })
+    check.assert({ hi: "world" })
+  })
+
+  test("rejects optional keys that exist, but are undefined", () => {
+    const check = t.exact({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    })
+    expect(() => {
+      check.assert({ hi: "world", opt: undefined })
+    }).toThrow()
+  })
 
   test("rejects supertypes", () => {
     const check = t.exact({

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -57,6 +57,16 @@ describe("subtype", () => {
     check.t({ email: 'bob@example.com' })
   })
 
+  test("slice omits optional keys that are not defined", () => {
+    const check = t.subtype({
+      email: t.str,
+      name: t.optional(t.str),
+    })
+
+    const result = check.slice({ email: 'bob@example.com' })
+    expect(Object.keys(result)).toEqual(['email'])
+  })
+
   test("rejects subtypes", () => {
     const check = t.subtype({
       hi: t.str,


### PR DESCRIPTION
Fixes #5 

- **BREAKING CHANGE**: Change t.optional(x) from x.or(undefined) to returning a non-Type box
  `OptionalKey` only accepted by t.subtype or t.exact. This box indicates
  that the property is *optional*, which means the key can be absent from
  valid definitions of the type.

- **BREAKING CHANGE**: Struct types will now throw if a key is marked
  t.optional(), but the key is defined and set to `undefined`. The
  correct type for this field in TypeScript is `keyName?: keyType |
  undefined`.

- Enhance the type-level inference system in struct.ts to produce
  optional keys for keys with OptionalKey boxes in them.

- Adjust tests for the breaking change to t.optional()