### PR TITLE
Add a `toTypescript` function to convert Structural types to TypeScript

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
 jobs:
   build:
     executor: node/default
+    resource_class: large
     environment:
       CC_TEST_REPORTER_ID: 339e5e314de7e8b7ae77047209233a42349cc928b2405aeef2d9dd33f68f1f98
     steps:

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ export * from "./lib/checks/is";
 export * from "./lib/checks/never";
 
 export * from "./lib/kind";
+export * from "./lib/to-ts";
 
 // TODO: test type inference. one way to do this: build up a struktural type, get the inner type
 // with GetType, and assign it something that should fail the type checker. assert the type checker

--- a/lib/checks/type-of.ts
+++ b/lib/checks/type-of.ts
@@ -1,9 +1,20 @@
 import { Err, Result } from "../result";
 import { Type } from "../type";
 
+export type ValidTypeString = "undefined"
+                            | "object"
+                            | "boolean"
+                            | "number"
+                            | "bigint"
+                            | "string"
+                            | "symbol"
+                            | "function"
+                            ;
+
 export class TypeOf<T> extends Type<T> {
-  readonly typestring: string;
-  constructor(t: string) {
+  readonly typestring: ValidTypeString;
+
+  constructor(t: ValidTypeString) {
     super();
     this.typestring = t;
   }
@@ -14,6 +25,6 @@ export class TypeOf<T> extends Type<T> {
   }
 }
 
-export function typeOf<T>(t: string): TypeOf<T> {
+export function typeOf<T>(t: ValidTypeString): TypeOf<T> {
   return new TypeOf<T>(t);
 }

--- a/lib/kind.ts
+++ b/lib/kind.ts
@@ -1,4 +1,4 @@
-import { Either, Intersect, Validation } from "./type";
+import { Comment, Either, Intersect, Validation } from "./type";
 import { TypeOf } from "./checks/type-of";
 import { InstanceOf } from "./checks/instance-of";
 import { Value } from "./checks/value";
@@ -25,4 +25,5 @@ export type Kind = Any
                  | Intersect<any, any>
                  | Validation<any>
                  | Is<any>
+                 | Comment<any>
                  ;

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -129,12 +129,14 @@ function fromInstanceOf(i: InstanceOf<any>) {
 }
 
 function fromValue(v: Value<any>) {
-  const vType = typeof v;
-  if(vType !== "string" && vType !== "number") {
+  const vType = typeof v.val;
+  if(vType !== "string" && vType !== "number" && v.val !== null && v.val !== undefined) {
     throw new Error(
-      "Only string and numeric value types are eligible for conversion to TypeScript"
+      "Only string, numeric, undefined, and null value types can be auto-converted to TypeScript"
     );
   }
+  if(vType === "string") return JSON.stringify(v.val);
+
   return `${v.val}`;
 }
 

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -1,0 +1,191 @@
+import { Type, Comment, Either, Intersect, Validation } from "./type";
+import { TypeOf } from "./checks/type-of";
+import { InstanceOf } from "./checks/instance-of";
+import { Value } from "./checks/value";
+import { Arr } from "./checks/array";
+import { Struct } from "./checks/struct";
+import { Dict } from "./checks/dict";
+import { MapType } from "./checks/map";
+import { SetType } from "./checks/set";
+import { Any } from "./checks/any";
+import { Is } from "./checks/is";
+import { Never } from "./checks/never";
+import { Kind } from "./kind";
+
+type ToTypescriptOpts = {
+  useReference?: {
+    [ref: string]: Type<any>,
+  },
+
+  indent: string,
+  indentLevel: number,
+};
+
+export type TypescriptUserOpts = Partial<ToTypescriptOpts> & {
+  assignToType?: string,
+};
+
+export default function toTypescript(type: Kind, userOpts: TypescriptUserOpts = {}): string {
+  const opts = Object.assign({ indent: "  ", indentLevel: 0 }, userOpts);
+  // assignToType is only valid at the top level, so delete it if it exists
+  delete opts.assignToType;
+
+  const ts = toTS(type, opts);
+
+  if(userOpts.assignToType) return `type ${userOpts.assignToType} = ${ts};`;
+  return ts;
+}
+
+function toTS(type: Kind, opts: ToTypescriptOpts): string {
+  if(opts.useReference) {
+    for(const key in opts.useReference) {
+      const val = opts.useReference[key];
+      if(val === type) return key;
+    }
+  }
+
+  if(type instanceof Comment) return fromComment(type, opts);
+  if(type instanceof Either) return fromEither(type, opts);
+  if(type instanceof Intersect) return fromIntersect(type, opts);
+  if(type instanceof Validation) return fromValidation();
+  if(type instanceof TypeOf) return fromTypeof(type);
+  if(type instanceof InstanceOf) return fromInstanceOf(type);
+  if(type instanceof Value) return fromValue(type);
+  if(type instanceof Arr) return fromArr(type, opts);
+  if(type instanceof Struct) return fromStruct(type, opts);
+  if(type instanceof Dict) return fromDict(type, opts);
+  if(type instanceof MapType) return fromMap(type, opts);
+  if(type instanceof SetType) return fromSet(type, opts);
+  if(type instanceof Any) return fromAny();
+  if(type instanceof Is) return fromIs(type);
+  return fromNever(type);
+}
+
+function fromComment(c: Comment<any>, opts: ToTypescriptOpts) {
+  const i = indent(opts);
+  const commentLines = formatCommentString(c.commentStr, opts);
+  return `${commentLines}\n${i}${toTS(c.wrapped, opts)}`;
+}
+
+function formatCommentString(commentStr: string, opts: ToTypescriptOpts) {
+  const i = indent(opts);
+  if(commentStr.indexOf("\n") < 0) {
+    return `// ${commentStr}`;
+  }
+
+  const lines = [ '/*' ]
+  for(const line of commentStr.split("\n")) {
+    lines.push(`${i} * ${line.trim()}`);
+  }
+  lines.push(`${i}*/`);
+  return lines.join("\n");
+}
+
+// TODO: Should either strip immediate-child comments?
+function fromEither(e: Either<any, any>, opts: ToTypescriptOpts) {
+  const i = indent(opts);
+  return [
+    toTS(e.l, opts),
+    `${i}${opts.indent}| ${toTS(e.r, {...opts, indentLevel: opts.indentLevel + 1})}`,
+  ].join("\n");
+}
+
+// TODO: Should intersect strip immediate-child comments?
+function fromIntersect(i: Intersect<any, any>, opts: ToTypescriptOpts) {
+  // Handle validations chained with actual TS types, converting them to comments
+  if(i.left instanceof Validation) return toTS(new Comment(i.left.desc, i.r), opts);
+  if(i.r instanceof Validation) return toTS(new Comment(i.r.desc, i.left), opts);
+
+  const indentation = indent(opts);
+  return [
+    toTS(i.left, opts),
+    `${indentation}${opts.indent}& ${toTS(i.r, {...opts, indentLevel: opts.indentLevel + 1})}`,
+  ].join("\n");
+}
+
+function fromValidation(): string {
+  throw new Error(
+    "Can't convert arbitrary validation functions to TypeScript types; make sure to .and() it " +
+      "with a valid type, and it will be converted into a comment above the type"
+  );
+}
+
+function fromTypeof(t: TypeOf<any>): string {
+  switch(t.typestring) {
+    case "undefined": return t.typestring;
+    case "object": return "Object";
+    case "boolean": return t.typestring;
+    case "number": return t.typestring;
+    case "bigint": return "BigInt";
+    case "string": return t.typestring;
+    case "symbol": return "Symbol";
+    case "function": return "Function";
+  }
+}
+
+function fromInstanceOf(i: InstanceOf<any>) {
+  return `${i.klass}`;
+}
+
+function fromValue(v: Value<any>) {
+  const vType = typeof v;
+  if(vType !== "string" && vType !== "number") {
+    throw new Error(
+      "Only string and numeric value types are eligible for conversion to TypeScript"
+    );
+  }
+  return `${v.val}`;
+}
+
+function fromArr(a: Arr<any>, opts: ToTypescriptOpts) {
+  return `Array<${toTS(a.elementType, opts)}>`;
+}
+
+// TODO: Note that what's very annoying about structs is you have to lift comments on values to
+// above the key, rather than doing key: //the comment\nthe value
+function fromStruct(s: Struct<any>, opts: ToTypescriptOpts) {
+  return "";
+}
+
+function fromDict(d: Dict<any>, opts: ToTypescriptOpts) {
+  const i = indent(opts);
+  const valString = toTS(d.valueType, {...opts, indentLevel: opts.indentLevel + 1});
+
+  // For single-line values, return a single-line dict
+  if(valString.indexOf("\n") < 0) return `{[key: string]: ${valString}}`;
+
+  // For multiline values, return a multiline dict
+  return [
+    "{",
+    `${i}${opts.indent}[key: string]: ${valString}`,
+    `${i}}`,
+  ].join("\n");
+}
+
+function fromMap(m: MapType<any, any>, opts: ToTypescriptOpts) {
+  const keyString = toTS(m.keyType, opts);
+  const valString = toTS(m.valueType, opts);
+  return `Map<${keyString}, ${valString}>`;
+}
+
+function fromSet(s: SetType<any>, opts: ToTypescriptOpts) {
+  const valString = toTS(s.valueType, opts);
+  return `Set<${valString}>`;
+}
+
+function fromAny() {
+  return "any";
+}
+
+function fromIs(i: Is<any>) {
+  return i.name;
+}
+
+// Despite not using the type, we take it to help ensure exhaustiveness checking in the toTS fn
+function fromNever(_: Never) {
+  return "never";
+}
+
+function indent(opts: ToTypescriptOpts) {
+  return opts.indent.repeat(opts.indentLevel);
+}

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -25,7 +25,7 @@ export type TypescriptUserOpts = Partial<ToTypescriptOpts> & {
   assignToType?: string,
 };
 
-export default function toTypescript(type: Kind, userOpts: TypescriptUserOpts = {}): string {
+export function toTypescript(type: Kind, userOpts: TypescriptUserOpts = {}): string {
   const opts = Object.assign({ indent: "  ", indentLevel: 0 }, userOpts);
   // assignToType is only valid at the top level, so delete it if it exists
   delete opts.assignToType;

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -124,7 +124,8 @@ function fromTypeof(t: TypeOf<any>): string {
 }
 
 function fromInstanceOf(i: InstanceOf<any>) {
-  return `${i.klass}`;
+  if(!i.klass.name) throw new Error("Can't convert anonymous classes to TypeScript");
+  return `${i.klass.name}`;
 }
 
 function fromValue(v: Value<any>) {

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -162,8 +162,10 @@ function fromStruct(s: Struct<any>, opts: ToTypescriptOpts) {
       lines.push(keyIndent + formatCommentString(stripped.comments.join("\n"), keyOpts));
     }
     keyType.push(toTS(stripped.inner, keyOpts));
+    keyType.push(",");
     lines.push(keyIndent + keyType.join(""));
   }
+  lines.push(indent(opts) + "}");
 
   return lines.join("\n");
 }

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -65,6 +65,15 @@ export abstract class Type<T> {
   validate(desc: string, fn: Validator<T>): Type<T> {
     return this.and(new Validation(desc, fn));
   }
+
+  /*
+   * Comments, for nice TypeScript exporting
+   * -----------------------------------------------------------------------------------------------
+   */
+
+  comment(comment: string): Type<T> {
+    return new Comment(comment, this);
+  }
 }
 
 function assert<T>(result: Result<T>): T {
@@ -82,6 +91,21 @@ function assert<T>(result: Result<T>): T {
  * class in order to extend it (since they themselves are Types).
  */
 
+/*
+ * ### Comment
+ *
+ * A type that delegates to the given type, but adds a comment when converted to TypeScript
+ */
+
+export class Comment<T> extends Type<T> {
+  constructor(readonly commentStr: string, readonly wrapped: Type<T>) {
+    super();
+  }
+
+  check(val: any): Result<T> {
+    return this.wrapped.check(val);
+  }
+}
 
 /*
  * ### Validation

--- a/test/algebra.ts
+++ b/test/algebra.ts
@@ -1,6 +1,10 @@
 import * as t from "..";
 
 describe("or", () => {
+  test("converts both sides to typescript", () => {
+    expect(t.toTypescript(t.num.or(t.str))).toEqual("number\n  | string");
+  });
+
   test("accepts either of the given checks", () => {
     const check = t.num.or(t.str);
     check.assert(5);

--- a/test/any.ts
+++ b/test/any.ts
@@ -5,3 +5,7 @@ test("accepts anything", () => {
   t.any.assert("five");
   t.any.assert({});
 });
+
+test("converts to typescript", () => {
+  expect(t.toTypescript(t.any)).toEqual("any");
+});

--- a/test/array.ts
+++ b/test/array.ts
@@ -1,5 +1,9 @@
 import * as t from "..";
 
+test("converts to typescript", () => {
+  expect(t.toTypescript(t.array(t.bool))).toEqual("Array<boolean>");
+});
+
 test("accepts the empty array", () => {
   const check = t.array(t.num);
   check.assert([]);

--- a/test/comment.ts
+++ b/test/comment.ts
@@ -1,0 +1,7 @@
+import * as t from "..";
+
+test("comments delegate checking to their wrapped values", () => {
+  const commentedNumber = t.num.comment("A number");
+  const num = commentedNumber.assert(5);
+  expect(num + 1).toEqual(6);
+});

--- a/test/dict.ts
+++ b/test/dict.ts
@@ -1,5 +1,15 @@
 import * as t from "..";
 
+test("converts to typescript", () => {
+  expect(t.toTypescript(t.dict(t.str))).toEqual("{[key: string]: string}");
+});
+
+test("converts to multiline typescript if necessary", () => {
+  expect(t.toTypescript(t.dict(t.exact({
+    key: t.bool,
+  })))).toEqual("{\n  [key: string]: {\n    key: boolean,\n  }\n}");
+});
+
 test("accepts empty dictionaries", () => {
   const check = t.dict(t.str);
   check.assert({});

--- a/test/instance-of.ts
+++ b/test/instance-of.ts
@@ -3,6 +3,16 @@ import * as t from "..";
 class A {}
 class B {}
 
+test("converts to typescript", () => {
+  expect(t.toTypescript(t.instanceOf(A))).toEqual("A");
+});
+
+test("throws an error on anon classes", () => {
+  expect(() => {
+    return t.toTypescript(t.instanceOf(class {}));
+  }).toThrow();
+});
+
 test("accepts values that are an instance of the class", () => {
   const check = t.instanceOf(A);
   check.assert(new A());

--- a/test/is.ts
+++ b/test/is.ts
@@ -1,5 +1,11 @@
 import * as t from "..";
 
+test("converts to typescript", () => {
+  expect(t.toTypescript(
+    t.is("string", (val: any): val is string => typeof val === "string")
+  )).toEqual("string");
+});
+
 test("passes when the fn returns true", () => {
   const check = t.is('string', (val: any): val is string => typeof val === 'string')
   check.assert('foo');

--- a/test/kind.ts
+++ b/test/kind.ts
@@ -50,6 +50,9 @@ test("allows type narrowing for exhaustiveness checking", () => {
     if (u instanceof t.Never) {
       return "never"
     }
+    if(u instanceof t.Comment) {
+      return "comment";
+    }
 
     // This should compile even though we never ran `if(u instanceof Validation)`, because we've
     // narrowed the type to just Validation by checking for everything else that `Kind` could be.

--- a/test/map.ts
+++ b/test/map.ts
@@ -1,5 +1,9 @@
 import * as t from "..";
 
+test("converts to typescript", () => {
+  expect(t.toTypescript(t.map(t.num, t.bool))).toEqual("Map<number, boolean>");
+});
+
 test("accepts empty maps", () => {
   const check = t.map(t.num, t.str);
   check.assert(new Map());

--- a/test/never.ts
+++ b/test/never.ts
@@ -1,5 +1,9 @@
 import * as t from "..";
 
+test("converts to typescript", () => {
+  expect(t.toTypescript(t.never)).toEqual("never");
+});
+
 // what a test.
 test("accepts nothing", () => {
   expect(() => {

--- a/test/primitives.ts
+++ b/test/primitives.ts
@@ -1,6 +1,10 @@
 import * as t from "..";
 
 describe("num", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.num)).toEqual("number");
+  });
+
   test("accepts numbers", () => {
     t.num.assert(1);
   });
@@ -17,6 +21,10 @@ describe("num", () => {
 });
 
 describe("str", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.str)).toEqual("string");
+  });
+
   test("accepts strings", () => {
     t.str.assert("hi");
   });
@@ -29,6 +37,10 @@ describe("str", () => {
 });
 
 describe("bool", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.bool)).toEqual("boolean");
+  });
+
   test("accepts booleans", () => {
     t.bool.assert(true);
   });
@@ -41,6 +53,10 @@ describe("bool", () => {
 });
 
 describe("fn", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.fn)).toEqual("Function");
+  });
+
   test("accepts functions", () => {
     t.fn.assert(() => {});
   });
@@ -53,6 +69,10 @@ describe("fn", () => {
 });
 
 describe("sym", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.sym)).toEqual("Symbol");
+  });
+
   test("accepts symbols", () => {
     t.sym.assert(Symbol());
   });
@@ -65,6 +85,10 @@ describe("sym", () => {
 });
 
 describe("undef", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.undef)).toEqual("undefined");
+  });
+
   test("accepts undefined", () => {
     t.undef.assert(undefined);
   });
@@ -77,6 +101,10 @@ describe("undef", () => {
 });
 
 describe("nil", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.nil)).toEqual("null");
+  });
+
   test("accepts null", () => {
     t.nil.assert(null);
   });
@@ -89,6 +117,10 @@ describe("nil", () => {
 });
 
 describe("obj", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.obj)).toEqual("Object");
+  });
+
   test("accepts objects", () => {
     t.obj.assert({});
     t.obj.assert({ five: "hi" });
@@ -103,6 +135,10 @@ describe("obj", () => {
 });
 
 describe("maybe", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.maybe(t.num))).toEqual("number\n  | null");
+  });
+
   test("accepts the matching value", () => {
     const check = t.maybe(t.num);
     check.assert(5);

--- a/test/set.ts
+++ b/test/set.ts
@@ -1,5 +1,9 @@
 import * as t from "..";
 
+test("converts to typescript", () => {
+  expect(t.toTypescript(t.set(t.num))).toEqual("Set<number>");
+});
+
 test("accepts values that match", () => {
   const check = t.set(t.num);
   const set = new Set<number>();

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -1,6 +1,29 @@
 import * as t from "..";
 
 describe("subtype", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.subtype({
+      hi: t.str,
+      world: t.subtype({
+        foo: t.num,
+      }),
+    }))).toEqual("{\n  hi: string,\n  world: {\n    foo: number,\n  },\n}");
+  });
+  test("puts value comments above the line", () => {
+    expect(t.toTypescript(t.subtype({
+      foo: t.subtype({
+        bar: t.str.comment("a comment"),
+      }),
+    }))).toEqual("{\n  foo: {\n    // a comment\n    bar: string,\n  },\n}");
+  });
+  test("puts multi-line value comments above the line with correct indentation", () => {
+    expect(t.toTypescript(t.subtype({
+      foo: t.subtype({
+        bar: t.str.comment("a comment\nabout this"),
+      }),
+    }))).toEqual("{\n  foo: {\n    /*\n     * a comment\n     * about this\n    */\n    bar: string,\n  },\n}");
+  });
+
   test("accepts exact matches", () => {
     const check = t.subtype({
       hi: t.str,

--- a/test/to-ts.ts
+++ b/test/to-ts.ts
@@ -1,0 +1,24 @@
+import * as t from "..";
+
+test("assigns to a type if the option is given", () => {
+  expect(
+    t.toTypescript(t.subtype({
+      orders: t.num,
+    }), { assignToType: "Customer" })
+  ).toEqual("type Customer = {\n  orders: number,\n};");
+});
+
+test("overwrites types with references if given the option", () => {
+  const Customer = t.subtype({
+    orders: t.num,
+  });
+  const Business = t.subtype({
+    users: t.array(Customer),
+  });
+
+  expect(t.toTypescript(Business, {
+    useReference: {
+      Customer,
+    }
+  })).toEqual("{\n  users: Array<Customer>,\n}");
+});

--- a/test/validate.ts
+++ b/test/validate.ts
@@ -1,5 +1,11 @@
 import * as t from "..";
 
+test("converts to typescript", () => {
+  expect(
+    t.toTypescript(t.num.validate("greater than zero", (num) => num > 0))
+  ).toEqual("// greater than zero\nnumber");
+});
+
 test("passes when the fn returns true", () => {
   const check = t.num.validate("between five and ten", (num) => {
     return num > 5 && num < 10;

--- a/test/value.ts
+++ b/test/value.ts
@@ -1,5 +1,23 @@
 import * as t from "..";
 
+test("converts to typescript if number", () => {
+  expect(t.toTypescript(t.value(5))).toEqual("5");
+});
+test("converts to typescript if string", () => {
+  expect(t.toTypescript(t.value("test"))).toEqual("\"test\"");
+});
+test("converts to typescript if null", () => {
+  expect(t.toTypescript(t.value(null))).toEqual("null");
+});
+test("converts to typescript if undefined", () => {
+  expect(t.toTypescript(t.value(undefined))).toEqual("undefined");
+});
+test("throws if non-convertible", () => {
+  expect(() => {
+    t.toTypescript(t.value(() => null));
+  }).toThrow();
+});
+
 test("accepts values that match", () => {
   const check = t.value(5);
   check.assert(5);


### PR DESCRIPTION
`Structural` runtime types are neat, but getting the actual compile-time TypeScript type out of it requires executing the TypeScript compiler ( by calling `t.GetType<...>`). That's  annoying if you want to, for example, auto-generate documentation without having to teach people how to use this library at the same time, and without doing a bunch of crazy TSC-wrapping build steps.

(Or, in my niche use-case, it's annoying to make documentation to send per-request to `gpt-3.5-turbo`; the AI understands TypeScript well enough, but has never seen Structural and is less proficient at understanding it.)

This PR adds a `toTypescript` function that can automatically generate a valid, readable TypeScript type definition as a string for a given Structural runtime type. It also adds a `.comment` builder function to all Type validators, so you can add comments to your TypeScript type definitions. For example:

```typescript
t.toTypescript({
  hi: t.value("world").comment("What a wonderful new feature Matt built"),
},);
```

Would generate the following TypeScript:

```typescript
{
  // What a wonderful new feature Matt built
  hi: "world",
}
```

As per the updated README, there are two options to `toTypescript`, meant to make the generated TypeScript files easier to read: `assignToType`, which assigns the type a name, and `useReference`, which allows you to replace deeply-nested references to other types with just a type name (rather than re-generating the entire type). Here's an annoying example that doesn't use those flags:

```typescript
const User = t.subtype({
  id: number,
});
const Booking = t.subtype({
  host: User,
  guest: User,
});

const userTS = t.toTypescript(User);
const bookingTS = t.toTypescript(Booking);
```

The `bookingTS` value will look super annoying!

```typescript
{
  host: {
    id: number,
  },
  guest: {
    id: number,
  },
}
```

While technically this is valid TypeScript, since TS uses structural subtyping... It's still a pain to read. Instead it would be nice to assign these types names and replace the repeated User references with the string `User`, instead of repeating the definition every time User gets used. Here's how you'd do that:

```typescript
const userTS = t.toTypescript(User, { assignToType: "User" });
const bookingTS = t.toTypescript(Booking, {
  assignToType: "Booking",
  useReference: {
    User,
  }
});
```

Then the combined `userTS + "\n" + bookingTS` would look like:

```typescript
type User = {
  id: number,
};
type Booking = {
  host: User,
  guest: User,
};
```

Sick.