### PR TITLE
Improve TypeScript generation

### DIFF
--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -136,9 +136,9 @@ function fromInstanceOf(i: InstanceOf<any>) {
 
 function fromValue(v: Value<any>) {
   const vType = typeof v.val;
-  if(vType !== "string" && vType !== "number" && v.val !== null && v.val !== undefined) {
+  if(vType !== "string" && vType !== "number" && vType !== "boolean" && v.val !== null && v.val !== undefined) {
     throw new Error(
-      "Only string, numeric, undefined, and null value types can be auto-converted to TypeScript"
+      "Only string, numeric, undefined, boolean, and null value types can be auto-converted to TypeScript"
     );
   }
   if(vType === "string") return JSON.stringify(v.val);

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -193,10 +193,16 @@ function stripOuterComments(t: Kind | OptionalKey<any>): StrippedComments {
   if(t instanceof Comment) {
     const inner = stripOuterComments(t.wrapped);
     return {
-      comments: [ t.commentStr, ...inner.comments ],
+      comments: [ ...inner.comments, t.commentStr ],
       inner: inner.inner,
     }
   }
+
+  if(t instanceof Intersect) {
+    if(t.left instanceof Validation) return stripOuterComments(new Comment(t.left.desc, t.r));
+    if(t.r instanceof Validation) return stripOuterComments(new Comment(t.r.desc, t.left));
+  }
+
   return {
     comments: [],
     inner: t,

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -69,15 +69,21 @@ function fromComment(c: Comment<any>, opts: ToTypescriptOpts) {
 
 function formatCommentString(commentStr: string, opts: ToTypescriptOpts) {
   const i = indent(opts);
-  if(commentStr.indexOf("\n") < 0) {
-    return `// ${commentStr}`;
+
+  const commentLines = commentStr.split("\n").map(line => {
+    return line.trim();
+  }).filter(line => line !== "");
+
+  if(commentLines.length === 0) return "";
+  if(commentLines.length === 1) {
+    return `// ${commentLines[0]}`;
   }
 
   const lines = [ '/*' ]
-  for(const line of commentStr.split("\n")) {
+  for(const line of commentLines) {
     lines.push(`${i} * ${line.trim()}`);
   }
-  lines.push(`${i}*/`);
+  lines.push(`${i} */`);
   return lines.join("\n");
 }
 

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -157,19 +157,26 @@ function fromStruct(s: Struct<any>, opts: ToTypescriptOpts) {
     indentLevel: opts.indentLevel + 1,
   };
   const keyIndent = indent(keyOpts);
+  const keys = Object.keys(s.definition);
 
-  for(const key in s.definition) {
+  for(let i = 0; i < keys.length; i++) {
+    const key = keys[i];
     const keyType = [ key ];
     const val = s.definition[key];
     if(val instanceof OptionalKey) keyType.push("?");
     keyType.push(": ");
     const stripped = stripOuterComments(val);
     if(stripped.comments.length > 0) {
+      // Visually separate the start of a commented field unless it's the first field
+      if(i !== 0) lines.push("");
+      // Put the comment on the line above the key
       lines.push(keyIndent + formatCommentString(stripped.comments.join("\n"), keyOpts));
     }
     keyType.push(toTS(stripped.inner, keyOpts));
     keyType.push(",");
     lines.push(keyIndent + keyType.join(""));
+    // Visually separate the end of a commented field, unless it's the last field
+    if(stripped.comments.length > 0 && i !== keys.length - 1) lines.push("");
   }
   lines.push(indent(opts) + "}");
 

--- a/test/comment.ts
+++ b/test/comment.ts
@@ -5,3 +5,13 @@ test("comments delegate checking to their wrapped values", () => {
   const num = commentedNumber.assert(5);
   expect(num + 1).toEqual(6);
 });
+
+test("multiline comments don't generate extra lines for pure whitespace", () => {
+  const commented = t.num.comment(`
+    A test multiline comment.
+    The preceding and trailing newlines should be ignored.
+  `);
+  expect(t.toTypescript(commented)).toEqual(
+    "/*\n * A test multiline comment.\n * The preceding and trailing newlines should be ignored.\n */\nnumber"
+  );
+});

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -21,7 +21,7 @@ describe("subtype", () => {
       foo: t.subtype({
         bar: t.str.comment("a comment\nabout this"),
       }),
-    }))).toEqual("{\n  foo: {\n    /*\n     * a comment\n     * about this\n    */\n    bar: string,\n  },\n}");
+    }))).toEqual("{\n  foo: {\n    /*\n     * a comment\n     * about this\n     */\n    bar: string,\n  },\n}");
   });
 
   test("accepts exact matches", () => {

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -1,6 +1,6 @@
 import * as t from "..";
 
-describe("subtype", () => {
+describe("converting to typescript", () => {
   test("converts to typescript", () => {
     expect(t.toTypescript(t.subtype({
       hi: t.str,
@@ -9,6 +9,7 @@ describe("subtype", () => {
       }),
     }))).toEqual("{\n  hi: string,\n  world: {\n    foo: number,\n  },\n}");
   });
+
   test("puts value comments above the line", () => {
     expect(t.toTypescript(t.subtype({
       foo: t.subtype({
@@ -16,6 +17,7 @@ describe("subtype", () => {
       }),
     }))).toEqual("{\n  foo: {\n    // a comment\n    bar: string,\n  },\n}");
   });
+
   test("puts multi-line value comments above the line with correct indentation", () => {
     expect(t.toTypescript(t.subtype({
       foo: t.subtype({
@@ -32,6 +34,14 @@ describe("subtype", () => {
     }))).toEqual("{\n  a: string,\n\n  // sup\n  b: string,\n\n  c: string,\n}")
   });
 
+  test("combines comments and validations into a single comment block", () => {
+    expect(t.toTypescript(t.subtype({
+      a: t.num.validate("Must be between 1-20.", num => num >= 1 && num <= 20).comment("Level.")
+    }))).toEqual("{\n  /*\n   * Must be between 1-20.\n   * Level.\n   */\n  a: number,\n}");
+  });
+});
+
+describe("subtype", () => {
   test("accepts exact matches", () => {
     const check = t.subtype({
       hi: t.str,

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -24,6 +24,14 @@ describe("subtype", () => {
     }))).toEqual("{\n  foo: {\n    /*\n     * a comment\n     * about this\n     */\n    bar: string,\n  },\n}");
   });
 
+  test("separates out fields in the middle of a fieldset the have comments", () => {
+    expect(t.toTypescript(t.subtype({
+      a: t.str,
+      b: t.str.comment("sup"),
+      c: t.str,
+    }))).toEqual("{\n  a: string,\n\n  // sup\n  b: string,\n\n  c: string,\n}")
+  });
+
   test("accepts exact matches", () => {
     const check = t.subtype({
       hi: t.str,

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -24,7 +24,7 @@ describe("subtype", () => {
     }))).toEqual("{\n  foo: {\n    /*\n     * a comment\n     * about this\n     */\n    bar: string,\n  },\n}");
   });
 
-  test("separates out fields in the middle of a fieldset the have comments", () => {
+  test("separates out fields in the middle of a fieldset that have comments", () => {
     expect(t.toTypescript(t.subtype({
       a: t.str,
       b: t.str.comment("sup"),


### PR DESCRIPTION
No plans survive contact with reality, I suppose. While #60 did generate correct TS configs, there was still some awkwardness around comment strings that real-world usage revealed (e.g. validation comments and comment strings were not combined well), and I also forgot to allow boolean values as value types, e.g. `t.toTypescript(t.value(true as const))` would explode.

This fixes the readability issues, allows boolean value types, and adds tests for these failure cases.