### PR TITLE
Keynames in generated TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,4 +546,3 @@ const businessTs = t.toTypescript(Business, {
 Any value in the `useReference` hash will be replaced in the TypeScript output
 with the key name. In this case, we're replacing `Customer` with `"Customer"`
 (and using object shorthand syntax to make that relatively ergonomic).
-

--- a/lib/checks/dict.ts
+++ b/lib/checks/dict.ts
@@ -7,9 +7,13 @@ type RawDict<V> = {
 
 export class Dict<V> extends Type<RawDict<V>> {
   readonly valueType: Type<V>;
-  constructor(v: Type<V>) {
+  constructor(v: Type<V>, readonly namedKey: string = "key") {
     super();
     this.valueType = v;
+  }
+
+  keyName(key: string): Dict<V> {
+    return new Dict(this.valueType, key);
   }
 
   check(val: any): Result<RawDict<V>> {

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -214,7 +214,7 @@ function fromDict(d: Dict<any>, opts: ToTypescriptOpts) {
   const valString = toTS(d.valueType, {...opts, indentLevel: opts.indentLevel + 1});
 
   // For single-line values, return a single-line dict
-  if(valString.indexOf("\n") < 0) return `{[key: string]: ${valString}}`;
+  if(valString.indexOf("\n") < 0) return `{[${d.namedKey}: string]: ${valString}}`;
 
   // For multiline values, return a multiline dict
   return [

--- a/test/dict.ts
+++ b/test/dict.ts
@@ -4,6 +4,10 @@ test("converts to typescript", () => {
   expect(t.toTypescript(t.dict(t.str))).toEqual("{[key: string]: string}");
 });
 
+test("converts to typescript with custom key name", () => {
+  expect(t.toTypescript(t.dict(t.str).keyName("name"))).toEqual("{[name: string]: string}")
+});
+
 test("converts to multiline typescript if necessary", () => {
   expect(t.toTypescript(t.dict(t.exact({
     key: t.bool,


### PR DESCRIPTION
It can be useful for documentation purposes to control the key names of dictionaries in generated TypeScript. For example, the following generated TypeScript could be clearer about what the keys are supposed to be:

```typescript
type OrderCount = {[key: string]: number};
```

By adding the `keyName` method to `Dict`s, it's now possible to control the keyname, e.g.

```typescript
const OrderCount = t.dict(t.num).keyName("customerName");
```

If you generate TypeScript from that with `t.toTypeScript(OrderCount, { assignToType: "OrderCount" })` it'll now generate:

```typescript
type OrderCount = {[customerName: string]: number};
```