### PR TITLE
Use const type annotation for Value types

### DIFF
--- a/lib/checks/value.ts
+++ b/lib/checks/value.ts
@@ -1,7 +1,7 @@
 import { Err, Result } from "../result";
 import { Type } from "../type";
 
-export class Value<T> extends Type<T> {
+export class Value<const T> extends Type<T> {
   readonly val: T;
   constructor(v: T) {
     super();


### PR DESCRIPTION
Uses [const type parameters](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters) from TypeScript 5.0 so that you don't have to manually annotate a bunch of `as const` stuff everywhere when using value types.