### PR TITLE
Add a more convenient mechanism for generating TS for several types at a time

### DIFF
--- a/test/to-ts.ts
+++ b/test/to-ts.ts
@@ -22,3 +22,16 @@ test("overwrites types with references if given the option", () => {
     }
   })).toEqual("{\n  users: Array<Customer>,\n}");
 });
+
+test("converts a whole bunch of types into a single readable TS output", () => {
+  const Customer = t.subtype({
+    orders: t.num,
+  });
+  const Business = t.subtype({
+    users: t.array(Customer),
+  });
+
+  expect(t.toTypescript({ Customer, Business })).toEqual(
+    "type Customer = {\n  orders: number,\n};\n\ntype Business = {\n  users: Array<Customer>,\n};"
+  );
+});


### PR DESCRIPTION
Adds a wrapper over `{ assignToType: string, useReference: {[name: string]: Kind}` so that instead of manually messing with a bunch of `useReference` hashes and manually assigning type names, you can instead just do:

```typescript
toTypescript({ Customer, Business });
```

And it'll generate the fully de-duped TS definition:

```typescript
type Customer = {
  orders: number,
};
type Business = {
  customers: Array<Customer>,
};
```

Instead of ending up with annoying duplicated structural types e.g.

```typescript
type Customer = {
  orders: number,
};
type Business = {
  customers: Array<{
    orders: number,
  }>,
};
```