### PR TITLE
Improves comment visual separation in the middle of structs

### DIFF
--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -191,13 +191,17 @@ function fromStruct(s: Struct<any>, opts: ToTypescriptOpts) {
     const stripped = stripOuterComments(val);
     if(stripped.comments.length > 0) {
       // Visually separate the start of a commented field unless it's the first field
-      if(i !== 0) lines.push("");
+      if(i !== 0) {
+        // But don't double-newline if you already separated the last line
+        if(lines[lines.length - 1] !== "") lines.push("");
+      }
       // Put the comment on the line above the key
       lines.push(keyIndent + formatCommentString(stripped.comments.join("\n"), keyOpts));
     }
     keyType.push(toTS(stripped.inner, keyOpts));
     keyType.push(",");
     lines.push(keyIndent + keyType.join(""));
+
     // Visually separate the end of a commented field, unless it's the last field
     if(stripped.comments.length > 0 && i !== keys.length - 1) lines.push("");
   }

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -34,6 +34,14 @@ describe("converting to typescript", () => {
     }))).toEqual("{\n  a: string,\n\n  // sup\n  b: string,\n\n  c: string,\n}")
   });
 
+  test("doesn't double-separate fields in the middle of a fieldset that have comments", () => {
+    expect(t.toTypescript(t.subtype({
+      a: t.str,
+      b: t.str.comment("sup"),
+      c: t.str.comment("yo"),
+    }))).toEqual("{\n  a: string,\n\n  // sup\n  b: string,\n\n  // yo\n  c: string,\n}")
+  });
+
   test("combines comments and validations into a single comment block", () => {
     expect(t.toTypescript(t.subtype({
       a: t.num.validate("Must be between 1-20.", num => num >= 1 && num <= 20).comment("Level.")


### PR DESCRIPTION
When generating TypeScript, we try to visually separate fields with comments in the middle of structs from other fields, to make it extra obvious which fields the comments apply to, like so:

```typescript
type Struct = {
  first: string,

  // Commented field
  second: string,

  third: string,
  fourth: string,
};
```

Previously, though, structs with comments would accidentally *over*-separate fields with comments from each other if the fields appeared sequentially, e.g.:

```typescript
type Struct = {
  first: string,

  // Commented field
  second: string,


  // Another commented field
  third: string,

  fourth: string,
};
```

This PR fixes that, so the formatting now looks like:

```typescript
type Struct = {
  first: string,

  // Commented field
  second: string,

  // Another commented field
  third: string,

  fourth: string,
```

It also adds a test for this behavior.