### PR TITLE
Partial and deepPartial

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ following advanced features:
   an object with both a `name` and an `eyeColor` is a valid `Person`.
 * __Algebraic data types:__ use `.and` and `.or` on types to compose them via
   type intersections or unions.
+* __Partial types:__ use `t.partial(...)` for an equivalent to `Partial<T>`,
+  and `t.deepPartial(...)` to make all nested types `Partial` as well.
 
 
 ## TypeScript integration

--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,7 @@ export * from "./lib/checks/primitives";
 export * from "./lib/checks/any";
 export * from "./lib/checks/is";
 export * from "./lib/checks/never";
+export * from "./lib/checks/partial";
 
 export * from "./lib/kind";
 export * from "./lib/to-ts";

--- a/lib/checks/partial.ts
+++ b/lib/checks/partial.ts
@@ -4,6 +4,7 @@ import { undef } from "./primitives";
 import { Dict } from "./dict";
 import { SetType } from "./set";
 import { Arr } from "./array";
+import { MapType } from "./map";
 
 
 type MakeOptional<T extends Type<any> | OptionalKey<any>> = T extends Type<any> ? OptionalKey<T> : T;
@@ -77,6 +78,7 @@ function deepPartialKind(kind: Type<any>): Type<any> {
   if(kind instanceof PartialStruct) return new DeepPartial(kind.struct);
   if(kind instanceof Dict) return new Dict(deepPartialKind(kind.valueType), kind.namedKey);
   if(kind instanceof SetType) return new SetType(deepPartialKind(kind.valueType));
+  if(kind instanceof MapType) return new MapType(deepPartialKind(kind.keyType), deepPartialKind(kind.valueType));
   if(kind instanceof Arr) return new Arr(deepPartialKind(kind.elementType));
   if(kind instanceof Either) return new Either(deepPartialKind(kind.l), deepPartialKind(kind.r));
   if(kind instanceof Intersect) {

--- a/lib/checks/partial.ts
+++ b/lib/checks/partial.ts
@@ -1,0 +1,73 @@
+import { Type, KeyTrackingType, KeyTrackResult } from "../type";
+import { Struct, optional, OptionalKey, TypeStruct, UnwrappedTypeStruct } from "./struct";
+import { undef } from "./primitives";
+
+
+type MakeOptional<T extends Type<any> | OptionalKey<any>> = T extends Type<any> ? OptionalKey<T> : T;
+
+type DeepPartialTypeStruct<T extends TypeStruct> = {
+  [K in keyof T]: T[K] extends Struct<infer T2> ? OptionalKey<Struct<DeepPartialTypeStruct<T2>>> :
+    MakeOptional<T[K]>
+}
+
+type PartialTypeStruct<T extends TypeStruct> = {
+  [K in keyof T]: MakeOptional<T[K]>
+};
+
+export class PartialStruct<T extends TypeStruct> extends KeyTrackingType<UnwrappedTypeStruct<PartialTypeStruct<T>>> {
+  private readonly hiddenStruct: Struct<PartialTypeStruct<T>>;
+  constructor(readonly struct: Struct<T>) {
+    super();
+    const partialDef: Partial<PartialTypeStruct<T>> = {};
+    for(const k in struct.definition) {
+      const v = struct.definition[k];
+      if(v instanceof OptionalKey) {
+        //@ts-ignore
+        partialDef[k] = optional(v.type.or(undef));
+      }
+      else {
+        //@ts-ignore
+        partialDef[k] = optional(v.or(undef));
+      }
+    }
+    this.hiddenStruct = new Struct(partialDef as PartialTypeStruct<T>, struct.exact);
+  }
+  checkTrackKeys(val: any): KeyTrackResult<UnwrappedTypeStruct<PartialTypeStruct<T>>> {
+    return this.hiddenStruct.checkTrackKeys(val);
+  }
+}
+
+export class DeepPartial<T extends TypeStruct> extends KeyTrackingType<UnwrappedTypeStruct<DeepPartialTypeStruct<T>>> {
+  readonly struct: Struct<DeepPartialTypeStruct<T>>;
+  constructor(struct: Struct<T>) {
+    super();
+    const partialDef: Partial<DeepPartialTypeStruct<T>> = {};
+    for(const k in struct.definition) {
+      const v = struct.definition[k];
+      if(v instanceof OptionalKey) {
+        //@ts-ignore
+        partialDef[k] = optional(v.type.or(undef));
+      }
+      else if(v instanceof Struct) {
+        //@ts-ignore
+        partialDef[k] = optional(new DeepPartial(v.definition, v.exact).or(undef));
+      }
+      else {
+        //@ts-ignore
+        partialDef[k] = optional(v.or(undef));
+      }
+    }
+    this.struct = new Struct(partialDef as DeepPartialTypeStruct<T>, struct.exact);
+  }
+
+  checkTrackKeys(val: any): KeyTrackResult<UnwrappedTypeStruct<DeepPartialTypeStruct<T>>> {
+    return this.struct.checkTrackKeys(val);
+  }
+}
+
+export function partial<T extends TypeStruct>(struct: Struct<T>): PartialStruct<T> {
+  return new PartialStruct(struct);
+}
+export function deepPartial<T extends TypeStruct>(struct: Struct<T>): DeepPartial<T> {
+  return new DeepPartial(struct);
+}

--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -16,7 +16,7 @@ export class OptionalKey<T extends Type<any>> {
 
 type OptionalOrType<T> = T extends OptionalKey<infer Inner> ? Inner : T;
 
-type TypeStruct = {
+export type TypeStruct = {
   [key: string]: Type<any> | OptionalKey<any>;
 };
 
@@ -103,13 +103,11 @@ export class Struct<T extends TypeStruct> extends KeyTrackingType<UnwrappedTypeS
   }
 }
 
-type HiddenStruct<T extends TypeStruct> = Type<UnwrappedTypeStruct<T>>;
-
-export function subtype<T extends TypeStruct>(def: T): HiddenStruct<T> {
+export function subtype<T extends TypeStruct>(def: T): Struct<T> {
   return new Struct(def, false);
 }
 
-export function exact<T extends TypeStruct>(def: T): HiddenStruct<T> {
+export function exact<T extends TypeStruct>(def: T): Struct<T> {
   return new Struct(def, true);
 }
 

--- a/lib/checks/value.ts
+++ b/lib/checks/value.ts
@@ -14,6 +14,6 @@ export class Value<const T> extends Type<T> {
   }
 }
 
-export function value<T>(v: T): Value<T> {
+export function value<const T>(v: T): Value<T> {
   return new Value(v);
 }

--- a/lib/kind.ts
+++ b/lib/kind.ts
@@ -10,6 +10,7 @@ import { SetType } from "./checks/set";
 import { Any } from "./checks/any";
 import { Is } from "./checks/is";
 import { Never } from "./checks/never";
+import { DeepPartial, PartialStruct } from "./checks/partial";
 
 export type Kind = Any
                  | Never
@@ -26,4 +27,6 @@ export type Kind = Any
                  | Validation<any>
                  | Is<any>
                  | Comment<any>
+                 | PartialStruct<any>
+                 | DeepPartial<any>
                  ;

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -10,6 +10,7 @@ import { SetType } from "./checks/set";
 import { Any } from "./checks/any";
 import { Is } from "./checks/is";
 import { Never } from "./checks/never";
+import { PartialStruct, DeepPartial } from "./checks/partial";
 import { Kind } from "./kind";
 
 type ToTypescriptOpts = {
@@ -81,7 +82,17 @@ function toTS(type: Kind, opts: ToTypescriptOpts): string {
   if(type instanceof SetType) return fromSet(type, opts);
   if(type instanceof Any) return fromAny();
   if(type instanceof Is) return fromIs(type);
+  if(type instanceof PartialStruct) return fromPartial(type, opts);
+  if(type instanceof DeepPartial) return fromDeepPartial(type, opts);
   return fromNever(type);
+}
+
+function fromPartial(p: PartialStruct<any>, opts: ToTypescriptOpts) {
+  return `Partial<${toTS(p.struct, opts)}>`;
+}
+
+function fromDeepPartial(p: DeepPartial<any>, opts: ToTypescriptOpts) {
+  return `Partial<${toTS(p.struct, opts)}>`;
 }
 
 function fromComment(c: Comment<any>, opts: ToTypescriptOpts) {

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -92,6 +92,7 @@ function fromPartial(p: PartialStruct<any>, opts: ToTypescriptOpts) {
 }
 
 function fromDeepPartial(p: DeepPartial<any>, opts: ToTypescriptOpts) {
+  if(!p.hasNested) return `Partial<${toTS(p.ogstruct, opts)}>`;
   return `Partial<${toTS(p.struct, opts)}>`;
 }
 

--- a/test/kind.ts
+++ b/test/kind.ts
@@ -53,6 +53,12 @@ test("allows type narrowing for exhaustiveness checking", () => {
     if(u instanceof t.Comment) {
       return "comment";
     }
+    if(u instanceof t.PartialStruct) {
+      return "partial";
+    }
+    if(u instanceof t.DeepPartial) {
+      return "deeppartial";
+    }
 
     // This should compile even though we never ran `if(u instanceof Validation)`, because we've
     // narrowed the type to just Validation by checking for everything else that `Kind` could be.

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -240,6 +240,15 @@ describe("deepPartial", () => {
 
     check.assert({ hi: { foo: "" } })
   });
+  test("allows previously-required nested keys to be missing from maps", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.map(t.subtype({
+        world: t.str,
+      }), t.subtype({ foo: t.str })),
+    }));
+
+    check.assert({ hi: new Map([ [{}, {}] ]) })
+  });
   test("converts nested partials to deep partials", () => {
     const check = t.deepPartial(t.subtype({
       hi: t.partial(t.subtype({

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -204,6 +204,42 @@ describe("deepPartial", () => {
 
     check.assert({ hi: { ok: {} } })
   });
+  test("allows previously-required nested keys to be missing from sets", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.set(t.subtype({
+        world: t.str,
+      })),
+    }));
+
+    check.assert({ hi: new Set([{}]) })
+  });
+  test("allows previously-required nested keys to be missing from arrays", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.array(t.subtype({
+        world: t.str,
+      })),
+    }));
+
+    check.assert({ hi: [{}] })
+  });
+  test("allows previously-required nested keys to be missing from eithers", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.subtype({
+        world: t.str,
+      }).or(t.str),
+    }));
+
+    check.assert({ hi: {} })
+  });
+  test("allows previously-required nested keys to be missing from intersects", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.subtype({
+        world: t.str,
+      }).and(t.subtype({ foo: t.str })),
+    }));
+
+    check.assert({ hi: { foo: "" } })
+  });
   test("converts nested partials to deep partials", () => {
     const check = t.deepPartial(t.subtype({
       hi: t.partial(t.subtype({

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -194,4 +194,25 @@ describe("deepPartial", () => {
 
     check.assert({ hi: {} })
   });
+
+  test("allows previously-required nested keys to be missing from dicts", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.dict(t.subtype({
+        world: t.str,
+      })),
+    }));
+
+    check.assert({ hi: { ok: {} } })
+  });
+  test("converts nested partials to deep partials", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.partial(t.subtype({
+        world: t.subtype({
+          foo: t.str,
+        }),
+      })),
+    }));
+
+    check.assert({ hi: { world: {} } })
+  });
 });

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -1,4 +1,57 @@
 import * as t from "..";
+describe("toTypescript", () => {
+  describe("partial", () => {
+    test("Uses Partial<> type signifier", () => {
+      const str = t.toTypescript(t.partial(t.subtype({
+        hi: t.str,
+      })));
+      expect(str).toEqual("Partial<{\n  hi: string,\n}>");
+    });
+    test("Correctly refs out inner structs", () => {
+      const a = t.subtype({
+        hi: t.str,
+      });
+      const b = t.partial(a);
+      const str = t.toTypescript({ a, b });
+      expect(str).toEqual(
+        "type a = {\n  hi: string,\n};\n\ntype b = Partial<a>;"
+      );
+    });
+  });
+
+  describe("deepPartial", () => {
+    test("Uses Partial<> type signifier", () => {
+      const str = t.toTypescript(t.partial(t.subtype({
+        hi: t.str,
+      })));
+      expect(str).toEqual("Partial<{\n  hi: string,\n}>");
+    });
+    test("Correctly refs out inner structs if they aren't further nested", () => {
+      const a = t.subtype({
+        hi: t.str,
+      });
+      const b = t.deepPartial(a);
+      const str = t.toTypescript({ a, b });
+      expect(str).toEqual(
+        "type a = {\n  hi: string,\n};\n\ntype b = Partial<a>;"
+      );
+    });
+    test("Doesn't ref out inner structs if they are further nested", () => {
+      const a = t.subtype({
+        hi: t.str,
+      });
+      const b = t.subtype({
+        a,
+      });
+      const c = t.deepPartial(b);
+      const str = t.toTypescript({ a, b, c });
+      expect(str).toEqual(
+        "type a = {\n  hi: string,\n};\n\ntype b = {\n  a: a,\n};\n\ntype c = Partial<{\n  a?: Partial<a>\n    | undefined,\n}>;"
+      );
+    });
+  });
+});
+
 describe("partial", () => {
   test("accepts exact matches", () => {
     const check = t.partial(t.subtype({

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -1,0 +1,144 @@
+import * as t from "..";
+describe("partial", () => {
+  test("accepts exact matches", () => {
+    const check = t.partial(t.subtype({
+      hi: t.str,
+    }));
+    check.assert({ hi: "world" });
+  });
+
+  test("accepts supertypes", () => {
+    const check = t.partial(t.subtype({
+      hi: t.str,
+    }));
+    check.assert({ hi: "world", foo: "bar" });
+  });
+
+  test("rejects supertypes with exact", () => {
+    const check = t.partial(t.exact({
+      hi: t.str,
+    }));
+    expect(() => {
+      check.assert({ hi: "world", foo: "bar" });
+    }).toThrow();
+  });
+
+  test("allows optional keys to be missing", () => {
+    const check = t.partial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({ hi: "world" })
+  });
+
+  test("allows optional keys that exist, but are undefined", () => {
+    const check = t.partial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({ hi: "world", opt: undefined })
+  });
+
+  test("allows previously-required keys to be missing", () => {
+    const check = t.partial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({})
+  });
+
+  test("allows previously-required keys to be undefined", () => {
+    const check = t.partial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({ hi: undefined })
+  });
+
+  test("does not allow previously-required nested keys to be missing", () => {
+    const check = t.partial(t.subtype({
+      hi: t.subtype({
+        world: t.str,
+      }),
+    }));
+
+    expect(() => {
+      check.assert({ hi: {} })
+    }).toThrow();
+  });
+});
+
+describe("deepPartial", () => {
+  test("accepts exact matches", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.str,
+    }));
+    check.assert({ hi: "world" });
+  });
+
+  test("accepts supertypes with subtype", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.str,
+    }));
+    check.assert({ hi: "world", foo: "bar" });
+  });
+
+  test("rejects supertypes with exact", () => {
+    const check = t.deepPartial(t.exact({
+      hi: t.str,
+    }));
+    expect(() => {
+      check.assert({ hi: "world", foo: "bar" });
+    }).toThrow();
+  });
+
+  test("allows optional keys to be missing", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({ hi: "world" })
+  });
+
+  test("allows optional keys that exist, but are undefined", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({ hi: "world", opt: undefined })
+  });
+
+  test("allows previously-required keys to be missing", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({})
+  });
+
+  test("allows previously-required keys to be undefined", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    }));
+
+    check.assert({ hi: undefined })
+  });
+
+  test("allows previously-required nested keys to be missing", () => {
+    const check = t.deepPartial(t.subtype({
+      hi: t.subtype({
+        world: t.str,
+      }),
+    }));
+
+    check.assert({ hi: {} })
+  });
+});


### PR DESCRIPTION
Adds a `.partial` type that is analogous to `Partial<T>`, and a `.deepPartial` type that makes all nested subtypes Partial, too.