### PR TITLE
Fix comment handling in deepPartial TS output

### DIFF
--- a/lib/checks/instance-of.ts
+++ b/lib/checks/instance-of.ts
@@ -1,7 +1,7 @@
 import { Err, Result } from "../result";
 import { Type } from "../type";
 
-type Constructor<T> = Function & { prototype: T }
+export type Constructor<T> = Function & { prototype: T }
 
 export class InstanceOf<T> extends Type<T> {
   readonly klass: Constructor<T>;

--- a/lib/checks/partial.ts
+++ b/lib/checks/partial.ts
@@ -1,4 +1,4 @@
-import { Type, KeyTrackingType, KeyTrackResult, Intersect, Either } from "../type";
+import { Type, KeyTrackingType, KeyTrackResult, Intersect, Either, Comment } from "../type";
 import { Struct, optional, OptionalKey, TypeStruct, UnwrappedTypeStruct } from "./struct";
 import { undef } from "./primitives";
 import { Dict } from "./dict";
@@ -77,6 +77,7 @@ export const Nested = [
   Arr,
   Either,
   Intersect,
+  Comment,
 ] as const;
 export type NestedType = InstanceType<(typeof Nested)[number]>;
 
@@ -93,12 +94,13 @@ function handleNested(kind: NestedType): Type<any> {
     return new PartialStruct(kind);
   }
   if(kind instanceof PartialStruct) return new DeepPartial(kind.struct);
+  if(kind instanceof Comment) return new Comment(kind.commentStr, deepPartialKind(kind.wrapped));
   if(kind instanceof Dict) return new Dict(deepPartialKind(kind.valueType), kind.namedKey);
   if(kind instanceof SetType) return new SetType(deepPartialKind(kind.valueType));
   if(kind instanceof MapType) return new MapType(deepPartialKind(kind.keyType), deepPartialKind(kind.valueType));
   if(kind instanceof Arr) return new Arr(deepPartialKind(kind.elementType));
   if(kind instanceof Either) return new Either(deepPartialKind(kind.l), deepPartialKind(kind.r));
-  return new Intersect(deepPartialKind(kind.left), deepPartialKind(kind.r));
+  return new Intersect(deepPartialKind(kind.l), deepPartialKind(kind.r));
 }
 
 function isNested(kind: Type<any> | NestedType): kind is NestedType {

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -252,18 +252,18 @@ export class Either<L, R> extends KeyTrackingType<L|R> {
  */
 
 export class Intersect<L, R> extends KeyTrackingType<L&R> {
-  readonly left: Type<L>;
+  readonly l: Type<L>;
   readonly r: Type<R>;
 
   constructor(l: Type<L>, r: Type<R>) {
     super();
 
-    this.left = l;
+    this.l = l;
     this.r = r;
   }
 
   checkTrackKeys(val: any): KeyTrackResult<L&R> {
-    const l = checkTrackKeys(this.left, val);
+    const l = checkTrackKeys(this.l, val);
     const r = checkTrackKeys(this.r, val);
 
     if((l instanceof Err) && (r instanceof Err)) {

--- a/test/match.ts
+++ b/test/match.ts
@@ -94,7 +94,7 @@ test("kind example", () => {
        .when(t.instanceOf(t.InstanceOf), ignore)
        .when(t.instanceOf(t.TypeOf), ignore)
        .when(t.instanceOf(t.Either), v => { recur(v.l); recur(v.r) })
-       .when(t.instanceOf(t.Intersect), v => { recur(v.left); recur(v.r) })
+       .when(t.instanceOf(t.Intersect), v => { recur(v.l); recur(v.r) })
        .when(t.instanceOf(t.Validation), ignore)
        .when(t.instanceOf(t.Is), ignore)
     )

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -62,6 +62,19 @@ describe("toTypescript", () => {
         "type a = {\n  hi: string,\n};\n\ntype b = {\n  a: {[key: string]: a},\n};\n\ntype c = Partial<{\n  a?: {[key: string]: Partial<a>}\n    | undefined,\n}>;"
       );
     });
+    test("Doesn't ref out inner structs if they are commented", () => {
+      const a = t.subtype({
+        hi: t.str,
+      });
+      const b = t.subtype({
+        a: a.comment("hi"),
+      });
+      const c = t.deepPartial(b);
+      const str = t.toTypescript({ a, b, c });
+      expect(str).toEqual(
+        "type a = {\n  hi: string,\n};\n\ntype b = {\n  // hi\n  a: a,\n};\n\ntype c = Partial<{\n  // hi\n  a?: Partial<a>\n    | undefined,\n}>;"
+      );
+    });
   });
 });
 


### PR DESCRIPTION
Previously, we didn't handle comments correctly in `.deepPartial` output. This revealed a further bug, which is that we didn't handle comments correctly inside structs with algebraic datatypes; and since `.deepPartial` automatically creates algebraic datatypes, fixing one also requires fixing the other.

This PR fixes both.