### PR TITLE
Make `optional()` keys TypeScript-compatible

### DIFF
--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -3,7 +3,7 @@ import { TypeOf } from "./checks/type-of";
 import { InstanceOf } from "./checks/instance-of";
 import { Value } from "./checks/value";
 import { Arr } from "./checks/array";
-import { Struct, OptionalKey } from "./checks/struct";
+import { Struct, MissingKey, OptionalKey } from "./checks/struct";
 import { Dict } from "./checks/dict";
 import { MapType } from "./checks/map";
 import { SetType } from "./checks/set";
@@ -198,6 +198,11 @@ function fromStruct(s: Struct<any>, opts: ToTypescriptOpts) {
     const key = keys[i];
     const keyType = [ key ];
     const val = s.definition[key];
+    if(val instanceof MissingKey) {
+      throw new Error(
+        "missing(...) fields can't be represented in TypeScript; consider using optional(...)"
+      );
+    }
     if(val instanceof OptionalKey) keyType.push("?");
     keyType.push(": ");
     const stripped = stripOuterComments(val);

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -46,7 +46,7 @@ describe("toTypescript", () => {
       const c = t.deepPartial(b);
       const str = t.toTypescript({ a, b, c });
       expect(str).toEqual(
-        "type a = {\n  hi: string,\n};\n\ntype b = {\n  a: a,\n};\n\ntype c = Partial<{\n  a?: Partial<a>\n    | undefined,\n}>;"
+        "type a = {\n  hi: string,\n};\n\ntype b = {\n  a: a,\n};\n\ntype c = Partial<{\n  a?: Partial<a>,\n}>;"
       );
     });
     test("Doesn't ref out inner structs if they are further nested in dicts", () => {
@@ -59,7 +59,7 @@ describe("toTypescript", () => {
       const c = t.deepPartial(b);
       const str = t.toTypescript({ a, b, c });
       expect(str).toEqual(
-        "type a = {\n  hi: string,\n};\n\ntype b = {\n  a: {[key: string]: a},\n};\n\ntype c = Partial<{\n  a?: {[key: string]: Partial<a>}\n    | undefined,\n}>;"
+        "type a = {\n  hi: string,\n};\n\ntype b = {\n  a: {[key: string]: a},\n};\n\ntype c = Partial<{\n  a?: {[key: string]: Partial<a>},\n}>;"
       );
     });
     test("Doesn't ref out inner structs if they are commented", () => {
@@ -72,7 +72,7 @@ describe("toTypescript", () => {
       const c = t.deepPartial(b);
       const str = t.toTypescript({ a, b, c });
       expect(str).toEqual(
-        "type a = {\n  hi: string,\n};\n\ntype b = {\n  // hi\n  a: a,\n};\n\ntype c = Partial<{\n  // hi\n  a?: Partial<a>\n    | undefined,\n}>;"
+        "type a = {\n  hi: string,\n};\n\ntype b = {\n  // hi\n  a: a,\n};\n\ntype c = Partial<{\n  // hi\n  a?: Partial<a>,\n}>;"
       );
     });
   });

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -73,15 +73,24 @@ describe("subtype", () => {
     check.assert({ hi: "world" })
   });
 
-  test("rejects optional keys that exist, but are undefined", () => {
+  test("rejects allow-missing keys that exist, but are undefined", () => {
     const check = t.subtype({
       hi: t.str,
-      opt: t.optional(t.bool),
+      opt: t.allowMissing(t.bool),
     });
 
     expect(() => {
       check.assert({ hi: "world", opt: undefined })
     }).toThrow();
+  });
+
+  test("allows optional keys that exist, but are undefined", () => {
+    const check = t.subtype({
+      hi: t.str,
+      opt: t.optional(t.bool),
+    });
+
+    check.assert({ hi: "world", opt: undefined })
   });
 
   test("type inference allows omitting optional keys", () => {
@@ -171,9 +180,27 @@ describe("exact", () => {
   test("allows optional keys to be missing", () => {
     const check = t.exact({
       hi: t.str,
+      opt: t.allowMissing(t.bool),
+    });
+    check.assert({ hi: "world" });
+  });
+
+  test("allows optional keys to be missing", () => {
+    const check = t.exact({
+      hi: t.str,
       opt: t.optional(t.bool),
     });
     check.assert({ hi: "world" });
+  });
+
+  test("rejects allow-missing keys that exist, but are undefined", () => {
+    const check = t.exact({
+      hi: t.str,
+      opt: t.allowMissing(t.bool),
+    });
+    expect(() => {
+      check.assert({ hi: "world", opt: undefined })
+    }).toThrow();
   });
 
   test("rejects optional keys that exist, but are undefined", () => {
@@ -181,9 +208,7 @@ describe("exact", () => {
       hi: t.str,
       opt: t.optional(t.bool),
     });
-    expect(() => {
-      check.assert({ hi: "world", opt: undefined })
-    }).toThrow();
+    check.assert({ hi: "world", opt: undefined })
   });
 
   test("rejects supertypes", () => {


### PR DESCRIPTION
The previous implementation of `optional()` broke compatibility with TypeScript's type system; in TS, optional keys may either be left out, or set to undefined. There isn't a built-in way to specify a key can be left out *but not set to undefined* in a structural type, outside of fairly awkward conditional type shenanigans; the built-in default ? syntax allows undefined.

However, Structural's built-in default of `optional(...)` did the opposite: it allowed the key to be left out, but failed if the key was present and the value was undefined. This was surprising, in that it differs from TS and Structural claims compatibility, and it was also painful for TS generation, since it meant that we'd generate slightly-invalid TypeScript if we tried to use optional keys for the Partials. To work around this, Structural's `partial(...)` family of functions *didn't* simply use `optional(...)`; it also applied a union to undefined, so that Structural's partial acted like TypeScript's Partial. But then the codegen was super awkward, since by default it kept the union type in, which is unnecessary bloat for TS since TS allows the union by default with just the ? syntax.

Rather than continue patching around our incompatibility, this commit makes `optional(...)` act like ? and accept undefined. If you really want the previous behavior, you can use the new `allowMissing(...)`, which uses the previous default behavior of allowing missing keys but failing on undefined.