### PR TITLE
Fix multiline named keys

### DIFF
--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -286,7 +286,7 @@ function fromDict(d: Dict<any>, opts: ToTypescriptOpts) {
   // For multiline values, return a multiline dict
   return [
     "{",
-    `${i}${opts.indent}[key: string]: ${valString}`,
+    `${i}${opts.indent}[${d.namedKey}: string]: ${valString}`,
     `${i}}`,
   ].join("\n");
 }

--- a/test/dict.ts
+++ b/test/dict.ts
@@ -11,7 +11,7 @@ test("converts to typescript with custom key name", () => {
 test("converts to multiline typescript if necessary", () => {
   expect(t.toTypescript(t.dict(t.exact({
     key: t.bool,
-  })))).toEqual("{\n  [key: string]: {\n    key: boolean,\n  }\n}");
+  })).keyName("k"))).toEqual("{\n  [k: string]: {\n    key: boolean,\n  }\n}");
 });
 
 test("accepts empty dictionaries", () => {


### PR DESCRIPTION
Previously, we left out the key name for multiline dicts. Now it's fixed, and there's a test.