### PR TITLE
Add toJSONSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ integration with its type system, allow TypeScript users to automatically get
 compile-time type inference for their Structural types in addition to runtime
 type checking. Structural types can also be automatically converted to actual,
 executable TypeScript automatically, for generating documentation or
-integrating with tools that understand TS type syntax.
+integrating with tools that understand TS type syntax, or converted to JSON
+Schema for integrating with non-JS/TS-based tooling.
 
 ### Table of contents
 
@@ -150,28 +151,24 @@ write the type out again in the rest of your code: it's automatically inferred.
   "properties": {
     "id": {
       "type": "number",
-      "description": "The user ID"
     },
     "name": {
       "type": "string",
-      "description": "The name of the user",
     },
     "login": {
       "type": "string",
-      "description": "The login username",
     },
     "hireable": {
       "type": "boolean",
-      "description": "Is the user hireable",
     }
   }
 }
 ```
 
-Clocking in at 23 lines of code, it's nearly 4x more verbose than the
-equivalent Structural validation. And for TypeScript users, JSON Schema is even
-worse! You'll also need the following redundant type declaration somewhere in
-your source files:
+Clocking in at 19 lines of code, it's over 3x more verbose than the equivalent
+Structural validation. And for TypeScript users, JSON Schema is even worse!
+You'll also need the following redundant type declaration somewhere in your
+source files:
 
 ```typescript
 type UserType = {
@@ -184,6 +181,14 @@ type UserType = {
 
 And every time you update the JSON Schema, you'll need to keep the type in
 sync, since it can't be inferred at compile time.
+
+If you really need JSON Schema -- for example, if you're integrating with
+external systems not written in JavaScript or TypeScript -- you can generate
+JSON Schema from Structural types in a single line of code:
+
+```typescript
+toJSONSchema("User schema", User)
+```
 
 ## Advanced type system features
 

--- a/index.ts
+++ b/index.ts
@@ -1,24 +1,10 @@
-export * from "./lib/result";
-export * from "./lib/type";
-export * from "./lib/get-type";
 export * from "./lib/match"
 
-export * from "./lib/checks/type-of";
-export * from "./lib/checks/instance-of";
-export * from "./lib/checks/value";
-export * from "./lib/checks/array";
-export * from "./lib/checks/struct";
-export * from "./lib/checks/dict";
-export * from "./lib/checks/map";
-export * from "./lib/checks/set";
-export * from "./lib/checks/primitives";
-export * from "./lib/checks/any";
-export * from "./lib/checks/is";
-export * from "./lib/checks/never";
-export * from "./lib/checks/partial";
+export * from "./lib/t";
+export * as t from "./lib/t";
 
-export * from "./lib/kind";
 export * from "./lib/to-ts";
+export * from "./lib/to-jsonschema";
 
 // TODO: test type inference. one way to do this: build up a struktural type, get the inner type
 // with GetType, and assign it something that should fail the type checker. assert the type checker

--- a/lib/kind.ts
+++ b/lib/kind.ts
@@ -1,16 +1,16 @@
-import { Comment, Either, Intersect, Validation } from "./type";
-import { TypeOf } from "./checks/type-of";
-import { InstanceOf } from "./checks/instance-of";
-import { Value } from "./checks/value";
-import { Arr } from "./checks/array";
-import { Struct } from "./checks/struct";
-import { Dict } from "./checks/dict";
-import { MapType } from "./checks/map";
-import { SetType } from "./checks/set";
-import { Any } from "./checks/any";
-import { Is } from "./checks/is";
-import { Never } from "./checks/never";
-import { DeepPartial, PartialStruct } from "./checks/partial";
+import type { Comment, Either, Intersect, Validation } from "./type";
+import type { TypeOf } from "./checks/type-of";
+import type { InstanceOf } from "./checks/instance-of";
+import type { Value } from "./checks/value";
+import type { Arr } from "./checks/array";
+import type { Struct } from "./checks/struct";
+import type { Dict } from "./checks/dict";
+import type { MapType } from "./checks/map";
+import type { SetType } from "./checks/set";
+import type { Any } from "./checks/any";
+import type { Is } from "./checks/is";
+import type { Never } from "./checks/never";
+import type { DeepPartial, PartialStruct } from "./checks/partial";
 
 export type Kind = Any
                  | Never

--- a/lib/t.ts
+++ b/lib/t.ts
@@ -1,0 +1,37 @@
+/*
+ * This is a smaller import, `t`, that only contains the basic matchers and code that would either
+ * necessarily be loaded to run them, or that takes 0 runtime space (e.g. type-only files).
+ * It exists to make it easy to import everything you would typically use to define schemas, but
+ * leave out optional stuff like converting to TypeScript, JSON Schema, etc from bundles, assuming
+ * you use a tree-shaking compiler. This effectively means that adding more conversion utilities
+ * doesn't bloat imports, and still provides reasonable import DX so that you don't need to have
+ * individual import statements for every single type. Instead of the old style:
+ *
+ *     import * as t from "structural";
+ *
+ * You can instead do:
+ *
+ *     import { t } from "structural";
+ *
+ * And save a little bundle space.
+ */
+
+export * from "./result";
+export * from "./type";
+export * from "./get-type";
+
+export * from "./checks/type-of";
+export * from "./checks/instance-of";
+export * from "./checks/value";
+export * from "./checks/array";
+export * from "./checks/struct";
+export * from "./checks/dict";
+export * from "./checks/map";
+export * from "./checks/set";
+export * from "./checks/primitives";
+export * from "./checks/any";
+export * from "./checks/is";
+export * from "./checks/never";
+export * from "./checks/partial";
+
+export * from "./kind";

--- a/lib/to-jsonschema.ts
+++ b/lib/to-jsonschema.ts
@@ -1,0 +1,306 @@
+import { Type, Comment, Either, Intersect, Validation } from "./type";
+import { TypeOf } from "./checks/type-of";
+import { InstanceOf } from "./checks/instance-of";
+import { Value } from "./checks/value";
+import { Arr } from "./checks/array";
+import { Struct, MissingKey, OptionalKey } from "./checks/struct";
+import { Dict } from "./checks/dict";
+import { MapType } from "./checks/map";
+import { SetType } from "./checks/set";
+import { Any } from "./checks/any";
+import { Is } from "./checks/is";
+import { Never } from "./checks/never";
+import { PartialStruct, DeepPartial } from "./checks/partial";
+import { Kind } from "./kind";
+
+export const JSON_SCHEMA_VERSION = "https://json-schema.org/draft/2020-12/schema" as const;
+type TopLevel<T> = T & {
+  $schema: typeof JSON_SCHEMA_VERSION,
+  title: string,
+};
+
+// TODO: a title annotation built into structural. description can be transformed from comments.
+// you should also have a variant of toJSONSchema that mandates top-level titles by insisting that
+// the type passed in is a Title type instead of a Kind type.
+type Annotated<T> = T & {
+  description?: string,
+};
+
+export type JSONValue = null
+                      | string
+                      | number
+                      | boolean
+                      | Array<JSONValue>
+                      | { [key: string]: JSONValue }
+                      ;
+
+export type JSONSchema = Annotated<{ type: "string" }>
+                       | Annotated<{ type: "number" }>
+                       | Annotated<{ type: "boolean" }>
+                       | Annotated<{ type: "null" }>
+                       | Annotated<{}> // {} is JSON schema's any type
+                       | Annotated<{
+                         type: "object",
+                         required: string[],
+                         properties: {
+                           [key: string]: JSONSchema,
+                         },
+                       }>
+                       | Annotated<{
+                         type: "object",
+                         // Dict<T> type is { properties: {}, additionalProperties: T }
+                         properties: {},
+                         additionalProperties?: JSONSchema,
+                       }>
+                       | Annotated<{
+                         type: "array",
+                         items?: JSONSchema,
+                       }>
+                       | Annotated<{
+                         // intersection
+                         allOf: JSONSchema[],
+                       }>
+                       | Annotated<{
+                         // union
+                         anyOf: JSONSchema[],
+                       }>
+                       | Annotated<{
+                         // technically this can be represented as anyOf([ ...consts ]), but for
+                         // readability if all of a union is const values imo you should output an
+                         // enum rather than the more complex type
+                         enum: Array<JSONValue>
+                       }>
+                       | Annotated<{
+                         const: JSONValue,
+                       }>
+                       ;
+
+type Options = {
+  errorOnValidations?: boolean,
+  errorOnIs?: boolean,
+  errorOnNever?: boolean,
+};
+const defaultOpts: Required<Options> = {
+  errorOnValidations: true,
+  errorOnIs: true,
+  errorOnNever: true,
+};
+
+export function toJSONSchema(title: string, type: Kind, opts?: Options): TopLevel<JSONSchema> {
+  const options = {
+    ...defaultOpts,
+    ...opts,
+  };
+
+  return addMetadata(title, typeToSchema(type, options));
+}
+
+function typeToSchema(type: Kind, options: Required<Options>): JSONSchema {
+  if(type instanceof Comment) {
+    return {
+      description: formatCommentString(type.commentStr),
+      ...typeToSchema(type.wrapped, options)
+    };
+  }
+  if(type instanceof Either) return fromEither(type, options);
+  if(type instanceof Intersect) return fromIntersect(type, options);
+  if(type instanceof Validation) return fromValidation(type, options);
+  if(type instanceof TypeOf) return fromTypeof(type);
+  if(type instanceof InstanceOf) {
+    throw `Structural instanceOf types can't be converted to JSON Schema`;
+  }
+  if(type instanceof Value) return fromValue(type);
+  if(type instanceof Arr) return fromArray(type, options);
+  if(type instanceof Struct) return fromStruct(type, options);
+  if(type instanceof Dict) return fromDict(type, options);
+  if(type instanceof MapType) {
+    throw `Structural Map types can't be converted to JSON Schema; consider using a dict`;
+  }
+  if(type instanceof SetType) {
+    throw `Structural Set types can't be converted to JSON Schema; consider using an array`;
+  }
+  if(type instanceof Any) {
+    return {};
+  }
+  if(type instanceof Is) return fromIs(type, options);
+  if(type instanceof Never) return fromNever(type, options);
+  if(type instanceof DeepPartial) return fromDeepPartial(type, options);
+
+  return fromPartial(type, options);
+}
+
+function areSerializableValues(types: Array<Type<any>>): types is Array<Value<JSONValue>> {
+  for(const type of types) {
+    if(!(type instanceof Value)) return false;
+    if(!isSerializable(type.val)) return false;
+  }
+  return true;
+}
+
+function isSerializable(value: any): value is JSONValue {
+  try {
+    JSON.parse(JSON.stringify(value));
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function fromEither(type: Either<any, any>, options: Required<Options>): JSONSchema {
+  // While the Either type could theoretically just map to recursive anyOf schemas, in practice it's
+  // much more readable to have it attempt to generate an enum list of all values (if it's a bunch
+  // of values unioned together, AND the values are all serializable to JSON), or a flat anyOf list
+  // otherwise. So, we walk the tree and collect all the types, and do that.
+  const allTypes = flatTypes(Either, type);
+
+  if(areSerializableValues(allTypes)) {
+    return {
+      enum: allTypes.map(t => t.val),
+    };
+  }
+
+  return {
+    anyOf: allTypes.map(type => typeToSchema(type, options)),
+  };
+}
+
+function fromIntersect(type: Intersect<any, any>, options: Required<Options>): JSONSchema {
+  if(type.r instanceof Validation) {
+    if(options.errorOnValidations) {
+      throw `Structural type contains a validation, but errorOnValidations was set to true`;
+    }
+    return {
+      description: type.r.desc,
+      ...typeToSchema(type.l, options),
+    };
+  }
+  return {
+    allOf: flatTypes(Intersect, type).map(t => typeToSchema(t, options)),
+  };
+}
+
+function fromValidation(type: Validation<any>, options: Required<Options>): JSONSchema {
+  if(options.errorOnValidations) {
+    throw `Structural type contains a validation, but errorOnValidations was set to true`;
+  }
+
+  return {
+    description: type.desc
+  };
+}
+
+function fromTypeof(type: TypeOf<any>): JSONSchema {
+  switch(type.typestring) {
+    case "string": return { type: "string" };
+    case "number": return { type: "number" };
+    case "boolean": return { type: "boolean" };
+    case "object": return { type: "object", properties: {} };
+  }
+  throw `Can't convert Structural TypeOf<${type.typestring}> checks into JSON Schema`
+}
+
+function fromValue(type: Value<any>): JSONSchema {
+  if(!isSerializable(type.val)) {
+    throw `Value type expects ${type.val}, but it isn't serializable to JSON`;
+  }
+
+  if(type.val === null) return { type: "null" };
+
+  return {
+    const: type.val,
+  };
+}
+
+function fromArray(type: Arr<any>, options: Required<Options>): JSONSchema {
+  return {
+    type: 'array',
+    items: typeToSchema(type.elementType, options),
+  };
+}
+
+function fromStruct(type: Struct<any>, options: Required<Options>): JSONSchema {
+  const properties: { [key: string]: JSONSchema } = {};
+  const required: string[] = [];
+  const keys = Object.keys(type.definition);
+  for(const key of keys) {
+    const val = type.definition[key];
+    if(val instanceof MissingKey || val instanceof OptionalKey) {
+      properties[key] = typeToSchema(val.type, options);
+    }
+    else {
+      required.push(key);
+      properties[key] = typeToSchema(val, options);
+    }
+  }
+
+  return {
+    type: 'object',
+    required, properties,
+  };
+}
+
+function fromDict(type: Dict<any>, options: Required<Options>): JSONSchema {
+  return {
+    type: 'object',
+    properties: {},
+    additionalProperties: typeToSchema(type.valueType, options),
+  };
+}
+
+function fromIs(type: Is<any>, options: Required<Options>) {
+  if(options.errorOnIs) {
+    throw `Structural type contains an Is check, but errorOnIs was set to true`;
+  }
+
+  return {
+    description: type.name,
+  };
+}
+
+function fromNever(_: Never, options: Required<Options>): JSONSchema {
+  if(options.errorOnNever) {
+    throw `Structural type contains a Never check, but errorOnNever was set to true`;
+  }
+
+  return {
+    allOf: [ { type: "string" }, { type: "number" } ],
+  };
+}
+
+function fromDeepPartial(type: DeepPartial<any>, options: Required<Options>): JSONSchema {
+  // DeepPartial's .struct accessor is actually a rewritten struct with all keys made deeply
+  // optional
+  return fromStruct(type.struct, options);
+}
+
+function fromPartial(type: PartialStruct<any>, options: Required<Options>): JSONSchema {
+  // Since Partial<T> only makes top-level keys optional, we just modify the required array
+  const schema = fromStruct(type.struct, options);
+  if('required' in schema) schema.required = [];
+  return schema;
+}
+
+function flatTypes(
+  klass: { new(...args: any): Either<any, any> | Intersect<any, any> },
+  node: Type<any>
+): Array<Type<any>> {
+  if(node instanceof klass) {
+    return flatTypes(klass, node.l).concat(flatTypes(klass, node.r));
+  }
+  return [ node ];
+}
+
+function formatCommentString(commentStr: string) {
+  const commentLines = commentStr.split("\n").map(line => {
+    return line.trim();
+  }).filter(line => line !== "");
+  return commentLines.join("\n");
+}
+
+function addMetadata(title: string, schema: JSONSchema): TopLevel<JSONSchema> {
+  return {
+    $schema: JSON_SCHEMA_VERSION,
+    title,
+    ...schema,
+  };
+}

--- a/test/any.ts
+++ b/test/any.ts
@@ -9,3 +9,10 @@ test("accepts anything", () => {
 test("converts to typescript", () => {
   expect(t.toTypescript(t.any)).toEqual("any");
 });
+
+test("converts to JSON schema", () => {
+  expect(t.toJSONSchema("any", t.any)).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "any",
+  });
+});

--- a/test/array.ts
+++ b/test/array.ts
@@ -4,6 +4,15 @@ test("converts to typescript", () => {
   expect(t.toTypescript(t.array(t.bool))).toEqual("Array<boolean>");
 });
 
+test("converts to JSONSchema", () => {
+  expect(t.toJSONSchema("arr<bool>", t.array(t.bool))).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "arr<bool>",
+    type: "array",
+    items: { type: "boolean" },
+  });
+});
+
 test("accepts the empty array", () => {
   const check = t.array(t.num);
   check.assert([]);

--- a/test/comment.ts
+++ b/test/comment.ts
@@ -15,3 +15,26 @@ test("multiline comments don't generate extra lines for pure whitespace", () => 
     "/*\n * A test multiline comment.\n * The preceding and trailing newlines should be ignored.\n */\nnumber"
   );
 });
+
+test("converts to JSON Schema description by default", () => {
+  const comment = t.num.comment("A number");
+  expect(t.toJSONSchema("num", comment)).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "num",
+    description: "A number",
+    type: "number",
+  });
+});
+
+test("Strips whitespace when converting to JSON Schema multiline", () => {
+  const comment = t.num.comment(`
+    A test multiline comment.
+    Indents should be ignored.
+  `);
+  expect(t.toJSONSchema("multiline", comment)).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "multiline",
+    description: "A test multiline comment.\nIndents should be ignored.",
+    type: "number",
+  });
+});

--- a/test/dict.ts
+++ b/test/dict.ts
@@ -4,6 +4,16 @@ test("converts to typescript", () => {
   expect(t.toTypescript(t.dict(t.str))).toEqual("{[key: string]: string}");
 });
 
+test("converts to JSON schema", () => {
+  expect(t.toJSONSchema("dict", t.dict(t.str))).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "dict",
+    type: "object",
+    properties: {},
+    additionalProperties: { type: "string" },
+  });
+});
+
 test("converts to typescript with custom key name", () => {
   expect(t.toTypescript(t.dict(t.str).keyName("name"))).toEqual("{[name: string]: string}")
 });

--- a/test/instance-of.ts
+++ b/test/instance-of.ts
@@ -7,6 +7,12 @@ test("converts to typescript", () => {
   expect(t.toTypescript(t.instanceOf(A))).toEqual("A");
 });
 
+test("can't convert to JSON Schema", () => {
+  expect(() => {
+    t.toJSONSchema("sure", t.instanceOf(class {}))
+  }).toThrow();
+});
+
 test("throws an error on anon classes", () => {
   expect(() => {
     return t.toTypescript(t.instanceOf(class {}));

--- a/test/is.ts
+++ b/test/is.ts
@@ -6,6 +6,24 @@ test("converts to typescript", () => {
   )).toEqual("string");
 });
 
+test("can't convert to JSON Schema", () => {
+  expect(() => {
+    t.toJSONSchema("bye", t.is("something", (val: any): val is string => typeof val === "string"));
+  }).toThrow();
+});
+
+test("can convert to JSON schema when errorOnIs is false", () => {
+  expect(t.toJSONSchema(
+    "str",
+    t.is("string", (val: any): val is string => typeof val === "string"),
+    { errorOnIs: false },
+  )).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "str",
+    description: "string",
+  });
+});
+
 test("passes when the fn returns true", () => {
   const check = t.is('string', (val: any): val is string => typeof val === 'string')
   check.assert('foo');

--- a/test/map.ts
+++ b/test/map.ts
@@ -4,6 +4,12 @@ test("converts to typescript", () => {
   expect(t.toTypescript(t.map(t.num, t.bool))).toEqual("Map<number, boolean>");
 });
 
+test("can't convert to JSON Schema", () => {
+  expect(() => {
+    t.toJSONSchema("bye", t.map(t.num, t.bool))
+  }).toThrow();
+});
+
 test("accepts empty maps", () => {
   const check = t.map(t.num, t.str);
   check.assert(new Map());

--- a/test/never.ts
+++ b/test/never.ts
@@ -4,6 +4,22 @@ test("converts to typescript", () => {
   expect(t.toTypescript(t.never)).toEqual("never");
 });
 
+test("can't convert to JSON schema by default", () => {
+  expect(() => {
+    t.toJSONSchema("huh", t.never);
+  }).toThrow();
+});
+
+test("converts to JSON Schema if errorOnNever is false", () => {
+  expect(t.toJSONSchema("huh", t.never, {
+    errorOnNever: false,
+  })).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "huh",
+    allOf: [ { type: "string" }, { type: "number" } ],
+  });
+});
+
 // what a test.
 test("accepts nothing", () => {
   expect(() => {

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -17,6 +17,29 @@ describe("toTypescript", () => {
         "type a = {\n  hi: string,\n};\n\ntype b = Partial<a>;"
       );
     });
+    test("Converts to JSON Schema, only affecting top-level keys", () => {
+      const a = t.subtype({
+        hi: t.str,
+      });
+      const b = t.subtype({
+        world: a,
+      });
+      expect(t.toJSONSchema("partial", t.partial(b))).toEqual({
+        $schema: t.JSON_SCHEMA_VERSION,
+        title: "partial",
+        type: "object",
+        required: [],
+        properties: {
+          world: {
+            type: "object",
+            required: [ "hi" ],
+            properties: {
+              hi: { type: "string" },
+            },
+          },
+        },
+      });
+    });
   });
 
   describe("deepPartial", () => {
@@ -74,6 +97,29 @@ describe("toTypescript", () => {
       expect(str).toEqual(
         "type a = {\n  hi: string,\n};\n\ntype b = {\n  // hi\n  a: a,\n};\n\ntype c = Partial<{\n  // hi\n  a?: Partial<a>,\n}>;"
       );
+    });
+    test("Converts to JSON Schema", () => {
+      const a = t.subtype({
+        hi: t.str,
+      });
+      const b = t.subtype({
+        a,
+      });
+      expect(t.toJSONSchema("deepPartial", t.deepPartial(b))).toEqual({
+        $schema: t.JSON_SCHEMA_VERSION,
+        title: "deepPartial",
+        type: "object",
+        required: [],
+        properties: {
+          a: {
+            type: "object",
+            required: [],
+            properties: {
+              hi: { type: "string" },
+            },
+          },
+        },
+      });
     });
   });
 });

--- a/test/primitives.ts
+++ b/test/primitives.ts
@@ -4,6 +4,13 @@ describe("num", () => {
   test("converts to typescript", () => {
     expect(t.toTypescript(t.num)).toEqual("number");
   });
+  test("converts to JSON schema", () => {
+    expect(t.toJSONSchema("num", t.num)).toEqual({
+      $schema: t.JSON_SCHEMA_VERSION,
+      title: "num",
+      type: "number",
+    });
+  });
 
   test("accepts numbers", () => {
     t.num.assert(1);
@@ -25,6 +32,14 @@ describe("str", () => {
     expect(t.toTypescript(t.str)).toEqual("string");
   });
 
+  test("converts to JSON Schema", () => {
+    expect(t.toJSONSchema("str", t.str)).toEqual({
+      $schema: t.JSON_SCHEMA_VERSION,
+      title: "str",
+      type: "string",
+    });
+  });
+
   test("accepts strings", () => {
     t.str.assert("hi");
   });
@@ -39,6 +54,14 @@ describe("str", () => {
 describe("bool", () => {
   test("converts to typescript", () => {
     expect(t.toTypescript(t.bool)).toEqual("boolean");
+  });
+
+  test("converts to JSON Schema", () => {
+    expect(t.toJSONSchema("bool", t.bool)).toEqual({
+      $schema: t.JSON_SCHEMA_VERSION,
+      title: "bool",
+      type: "boolean",
+    });
   });
 
   test("accepts booleans", () => {
@@ -57,6 +80,12 @@ describe("fn", () => {
     expect(t.toTypescript(t.fn)).toEqual("Function");
   });
 
+  test("can't convert to JSON Schema", () => {
+    expect(() => {
+      t.toJSONSchema("no", t.fn);
+    }).toThrow();
+  });
+
   test("accepts functions", () => {
     t.fn.assert(() => {});
   });
@@ -71,6 +100,12 @@ describe("fn", () => {
 describe("sym", () => {
   test("converts to typescript", () => {
     expect(t.toTypescript(t.sym)).toEqual("Symbol");
+  });
+
+  test("can't convert to JSON Schema", () => {
+    expect(() => {
+      t.toJSONSchema("no", t.sym);
+    }).toThrow();
   });
 
   test("accepts symbols", () => {
@@ -89,6 +124,12 @@ describe("undef", () => {
     expect(t.toTypescript(t.undef)).toEqual("undefined");
   });
 
+  test("can't convert to JSON Schema", () => {
+    expect(() => {
+      t.toJSONSchema("no", t.undef);
+    }).toThrow();
+  });
+
   test("accepts undefined", () => {
     t.undef.assert(undefined);
   });
@@ -105,6 +146,14 @@ describe("nil", () => {
     expect(t.toTypescript(t.nil)).toEqual("null");
   });
 
+  test("converts to JSON Schema", () => {
+    expect(t.toJSONSchema("null", t.nil)).toEqual({
+      $schema: t.JSON_SCHEMA_VERSION,
+      title: "null",
+      type: "null",
+    });
+  });
+
   test("accepts null", () => {
     t.nil.assert(null);
   });
@@ -119,6 +168,15 @@ describe("nil", () => {
 describe("obj", () => {
   test("converts to typescript", () => {
     expect(t.toTypescript(t.obj)).toEqual("Object");
+  });
+
+  test("converts to JSON schema", () => {
+    expect(t.toJSONSchema("obj", t.obj)).toEqual({
+      $schema: t.JSON_SCHEMA_VERSION,
+      title: "obj",
+      type: "object",
+      properties: {},
+    });
   });
 
   test("accepts objects", () => {

--- a/test/set.ts
+++ b/test/set.ts
@@ -4,6 +4,12 @@ test("converts to typescript", () => {
   expect(t.toTypescript(t.set(t.num))).toEqual("Set<number>");
 });
 
+test("can't convert to JSON Schema", () => {
+  expect(() => {
+    t.toJSONSchema("no", t.set(t.num));
+  }).toThrow();
+});
+
 test("accepts values that match", () => {
   const check = t.set(t.num);
   const set = new Set<number>();

--- a/test/to-jsonschema.ts
+++ b/test/to-jsonschema.ts
@@ -1,0 +1,39 @@
+import * as t from "..";
+
+test("converts a whole bunch of types", () => {
+  const Customer = t.subtype({
+    orders: t.num,
+    migrated: t.optional(t.bool),
+  });
+  const Business = t.subtype({
+    users: t.array(Customer),
+    orgChart: t.dict(t.str),
+  });
+
+  expect(t.toJSONSchema("business", Business)).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "business",
+    type: "object",
+    required: [ "users", "orgChart" ],
+    properties: {
+      orgChart: {
+        type: "object",
+        properties: {},
+        additionalProperties: {
+          type: "string",
+        },
+      },
+      users: {
+        type: "array",
+        items: {
+          type: "object",
+          required: [ "orders" ],
+          properties: {
+            orders: { type: "number" },
+            migrated: { type: "boolean" },
+          },
+        },
+      },
+    },
+  });
+});

--- a/test/to-jsonschema.ts
+++ b/test/to-jsonschema.ts
@@ -3,7 +3,7 @@ import * as t from "..";
 test("converts a whole bunch of types", () => {
   const Customer = t.subtype({
     orders: t.num,
-    migrated: t.optional(t.bool),
+    migrated: t.optional(t.bool.comment("Are they migrated to the new system?")),
   });
   const Business = t.subtype({
     users: t.array(Customer),
@@ -30,7 +30,10 @@ test("converts a whole bunch of types", () => {
           required: [ "orders" ],
           properties: {
             orders: { type: "number" },
-            migrated: { type: "boolean" },
+            migrated: {
+              type: "boolean",
+              description: "Are they migrated to the new system?",
+            },
           },
         },
       },

--- a/test/validate.ts
+++ b/test/validate.ts
@@ -6,6 +6,25 @@ test("converts to typescript", () => {
   ).toEqual("// greater than zero\nnumber");
 });
 
+test("converts to JSON schema as a comment when errorOnValidations is false", () => {
+  expect(
+    t.toJSONSchema(">0", t.num.validate("greater than zero", (num) => num > 0), {
+      errorOnValidations: false,
+    })
+  ).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: ">0",
+    description: "greater than zero",
+    type: "number",
+  });
+});
+
+test("can't convert to JSON Schema by default", () => {
+  expect(() => {
+    t.toJSONSchema(">0", t.num.validate("greater than zero", (num) => num > 0))
+  }).toThrow();
+});
+
 test("passes when the fn returns true", () => {
   const check = t.num.validate("between five and ten", (num) => {
     return num > 5 && num < 10;

--- a/test/value.ts
+++ b/test/value.ts
@@ -3,6 +3,13 @@ import * as t from "..";
 test("converts to typescript if number", () => {
   expect(t.toTypescript(t.value(5))).toEqual("5");
 });
+test("converts to JSON Schema if number", () => {
+  expect(t.toJSONSchema('const', t.value(5))).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "const",
+    const: 5,
+  });
+});
 test("converts to typescript if string", () => {
   expect(t.toTypescript(t.value("test"))).toEqual("\"test\"");
 });
@@ -12,9 +19,15 @@ test("converts to typescript if null", () => {
 test("converts to typescript if undefined", () => {
   expect(t.toTypescript(t.value(undefined))).toEqual("undefined");
 });
-test("throws if non-convertible", () => {
+test("throws if non-convertible to typescript", () => {
   expect(() => {
     t.toTypescript(t.value(() => null));
+  }).toThrow();
+});
+
+test("throws if not convertable to JSON Schema", () => {
+  expect(() => {
+    t.toJSONSchema("no", t.value(() => null));
   }).toThrow();
 });
 


### PR DESCRIPTION
Adds a top-level `toJSONSchema` function to convert Structural types to JSON Schema.

Also adds a `t` export that contains only the type check constructors, so that you can do:

```typescript
import { t } from "structural";

t.subtype({
  // ...
});
```

Which means assuming you're using a tree-shaking compiler, the `toJSONSchema` function and similar conversion utilities won't add any bloat to your build (unless you use them).