### PR TITLE
Fix container slicing

### DIFF
--- a/lib/checks/array.ts
+++ b/lib/checks/array.ts
@@ -21,6 +21,20 @@ export class Arr<T> extends Type<Array<T>> {
     // If we got this far, there were no errors; it's an Array<T>
     return val as Array<T>;
   }
+
+  sliceResult(val: any): Result<Array<T>> {
+    if(!Array.isArray(val)) return new Err(`${val} is not an array`);
+
+    const result: T[] = [];
+    for(const el of val) {
+      const sliced = this.elementType.slice(el);
+      // Don't bother collecting all errors in an array: for long arrays this is very obnoxious
+      if(result instanceof Err) return new Err(result.message);
+      result.push(sliced);
+    }
+
+    return result;
+  }
 }
 
 export function array<T>(t: Type<T>): Arr<T> {

--- a/lib/checks/dict.ts
+++ b/lib/checks/dict.ts
@@ -17,9 +17,8 @@ export class Dict<V> extends Type<RawDict<V>> {
   }
 
   check(val: any): Result<RawDict<V>> {
-    if(typeof val !== 'object') return new Err(`${val} is not an object`);
-    if(Array.isArray(val)) return new Err(`${val} is an array`);
-    if(val === null) return new Err(`${val} is null`);
+    const err = basicErrs(val);
+    if(err) return err;
 
     for(const prop in val) {
       const result = this.valueType.check(val[prop]);
@@ -28,6 +27,27 @@ export class Dict<V> extends Type<RawDict<V>> {
 
     return val as Result<RawDict<V>>;
   }
+
+  sliceResult(val: any): Result<RawDict<V>> {
+    const err = basicErrs(val);
+    if(err) return err;
+
+    const result: { [key: string]: any } = {};
+    for(const prop in val) {
+      const sliced = this.valueType.slice(val[prop]);
+      if(sliced instanceof Err) return new Err(`[${prop}]: ${result.message}`);
+      result[prop] = sliced;
+    }
+
+    return result as Result<RawDict<V>>;
+  }
+}
+
+function basicErrs<V>(val: any): Err<V> | null {
+  if(typeof val !== 'object') return new Err(`${val} is not an object`);
+  if(Array.isArray(val)) return new Err(`${val} is an array`);
+  if(val === null) return new Err(`${val} is null`);
+  return null;
 }
 
 export function dict<V>(v: Type<V>): Dict<V> {

--- a/lib/checks/map.ts
+++ b/lib/checks/map.ts
@@ -23,6 +23,22 @@ export class MapType<K, V> extends Type<Map<K, V>> {
 
     return val as Map<K, V>;
   }
+
+  sliceResult(val: any): Result<Map<K, V>> {
+    if(!(val instanceof Map)) return new Err(`${val} is not an instance of Map`);
+
+    const result: Map<K, V> = new Map();
+
+    for(const [k, v] of val) {
+      const kResult = this.keyType.slice(k);
+      if(kResult instanceof Err) return new Err(`{val} key error: ${kResult.message}`);
+      const vResult = this.valueType.slice(v);
+      if(vResult instanceof Err) return new Err(`{val} value error: ${vResult.message}`);
+      result.set(kResult, vResult);
+    }
+
+    return result;
+  }
 }
 
 export function map<K, V>(k: Type<K>, v: Type<V>): MapType<K, V> {

--- a/lib/checks/set.ts
+++ b/lib/checks/set.ts
@@ -17,6 +17,17 @@ export class SetType<V> extends Type<Set<V>> {
     }
     return val as Set<V>;
   }
+
+  sliceResult(val: any): Result<Set<V>> {
+    if(!(val instanceof Set)) return new Err(`${val} is not an instance of Set`);
+    const result = new Set<V>();
+    for(const v of val) {
+      const sliced = this.valueType.sliceResult(v);
+      if(sliced instanceof Err) return new Err(`{val} failed set check on value ${v}: ${sliced.message}`);
+      result.add(sliced);
+    }
+    return result;
+  }
 }
 
 export function set<V>(v: Type<V>): SetType<V> {

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -293,7 +293,7 @@ export class Intersect<L, R> extends KeyTrackingType<L&R> {
  * Given a type and a value, safely check it, returning a KeyTrackResult for it. This function works
  * regardless of whether or not the underlying type is a KeyTrackingType.
  */
-function checkTrackKeys<T>(check: Type<T>, val: any): KeyTrackResult<T> {
+export function checkTrackKeys<T>(check: Type<T>, val: any): KeyTrackResult<T> {
   if(check instanceof KeyTrackingType) {
     return check.checkTrackKeys(val);
   }

--- a/test/array.ts
+++ b/test/array.ts
@@ -36,3 +36,14 @@ test("rejects non-arrays", () => {
     check.assert(null);
   }).toThrow();
 });
+
+test("sliced nested objects", () => {
+  const check = t.array(t.subtype({
+    id: t.str,
+  }));
+  const result = check.slice([
+    { id: "hello", name: "world" }
+  ]);
+  const data: any = result[0];
+  expect(data["name"]).toBeUndefined();
+});

--- a/test/dict.ts
+++ b/test/dict.ts
@@ -66,3 +66,17 @@ test("rejects arrays", () => {
     check.assert([ ]);
   }).toThrow();
 });
+
+test("sliced nested objects", () => {
+  const nested = t.subtype({ id: t.str });
+  const check = t.dict(nested);
+  const dict: { [key: string]: any } = {};
+  dict["hello"] = {
+    id: "world",
+    name: "blarg",
+  };
+  const result = check.slice(dict);
+  const data: any = result["hello"];
+  expect(data["id"]).toBe("world");
+  expect(data["name"]).toBeUndefined();
+});

--- a/test/map.ts
+++ b/test/map.ts
@@ -46,3 +46,16 @@ test("rejects non-maps", () => {
     check.assert(null);
   }).toThrow();
 });
+
+test("sliced nested objects", () => {
+  const nested = t.subtype({ id: t.str });
+  const check = t.map(t.str, nested);
+  const map = new Map<string, t.GetType<typeof nested>>();
+  map.set("hello", {
+    id: "world",
+    name: "blarg",
+  } as t.GetType<typeof nested>);
+  const result = check.slice(map);
+  const data: any = result.get("hello");
+  expect(data["name"]).toBeUndefined();
+});

--- a/test/set.ts
+++ b/test/set.ts
@@ -38,3 +38,16 @@ test("rejects non-sets", () => {
     check.assert(null);
   }).toThrow();
 });
+
+test("sliced nested objects", () => {
+  const nested = t.subtype({ id: t.str });
+  const check = t.set(nested);
+  const set = new Set<t.GetType<typeof nested>>();
+  set.add({
+    id: "world",
+    name: "blarg",
+  } as t.GetType<typeof nested>);
+  const result = check.slice(set);
+  const data: any = Array.from(result)[0];
+  expect(data["name"]).toBeUndefined();
+});


### PR DESCRIPTION
Previously, containers (arrays, dicts, maps, sets) were implemented as ordinary Types without any special slicing overrides. Unfortunately, this means their `sliceResult` implementation — the basis of all slicing — was implemented as just a call to `.check(val)`... So the containers never actually sliced anything, and nested objects were copied rather than sliced.

This fixes the bug and adds tests for all of the container classes slicing their nested objects.