### PR TITLE
Fix partial and struct merging

### DIFF
--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -334,16 +334,15 @@ export class MergeIntersect<
   constructor(readonly l: L, readonly r: R) {
     super();
 
-    if(l instanceof Dict) {
-      this.merged = this.mergeDictAndMergeable(l, r);
-    }
-    else if(l instanceof Struct) {
-      this.merged = this.mergeStructAndMergeable(l, r);
-    }
-    else {
-      // @ts-ignore
-      this.merged = this.mergeIntersectAndMergeable(l, r);
-    }
+    this.merged = merge(l, {
+      dict: l => this.mergeDictAndMergeable(l, r),
+      struct: l => this.mergeStructAndMergeable(l, r),
+      partial: l => this.mergeStructAndMergeable(l.reify(), r),
+      merge: l => this.mergeIntersectAndMergeable(l, r),
+      internal: () => {
+        throw `leaked internal dict/struct merge class; structural error`;
+      },
+    });
   }
 
   check(val: any) {

--- a/test/algebra.ts
+++ b/test/algebra.ts
@@ -519,4 +519,25 @@ describe("and", () => {
 
     expect(Object.keys(sliced).sort()).toEqual([ "hi", "world" ].sort());
   });
+
+  test("merging nested partials and non-partials", () => {
+    const combat = t.value("dps").comment("damage-focused");
+    const chardata = t.subtype({
+      mainRole: combat,
+    });
+    const mergedchar = t.subtype({
+      charData: t.partial(chardata).and(chardata),
+    });
+    const sliced = mergedchar.slice({
+      charData: {
+        mainRole: 'dps',
+        extra: 'hello',
+      },
+    });
+    expect(sliced).toEqual({
+      charData: {
+        mainRole: 'dps',
+      },
+    });
+  });
 });


### PR DESCRIPTION
Merging Structs and PartialStructs in the new, keytrackless world wasn't fully implemented and could result in an undefined type error. This fixes that, and adds a test.