### PR TITLE
Add primitive bigint type

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ toJSONSchema("User schema", User)
 * `t.map(key, value)` corresponds to `Map<Key, Value>`
 * `t.never` corresponds to `never`
 * `t.num` corresponds to `number`
+* `t.bigint` corresponds to `bigint`
 * `t.str` corresponds to `string`
 * `t.bool` corresponds to `boolean`
 * `t.fn` corresponds to `Function`

--- a/lib/checks/primitives.ts
+++ b/lib/checks/primitives.ts
@@ -3,6 +3,7 @@ import { typeOf } from "./type-of";
 import { value } from "./value";
 
 export const num = typeOf<number>('number');
+export const bigint = typeOf<bigint>('bigint');
 export const str = typeOf<string>('string');
 export const bool = typeOf<boolean>('boolean');
 export const fn = typeOf<Function>('function');

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -153,10 +153,10 @@ function fromTypeof(t: TypeOf<any>): string {
     case "object": return "Object";
     case "boolean": return t.typestring;
     case "number": return t.typestring;
-    case "bigint": return "BigInt";
     case "string": return t.typestring;
     case "symbol": return "Symbol";
     case "function": return "Function";
+    case "bigint": return "bigint";
   }
 }
 

--- a/test/primitives.ts
+++ b/test/primitives.ts
@@ -27,6 +27,17 @@ describe("num", () => {
   });
 });
 
+describe("bigint", () => {
+  test("converts to typescript", () => {
+    expect(t.toTypescript(t.bigint)).toEqual("bigint");
+  });
+  test("can't convert to JSON Schema", () => {
+    expect(() => {
+      t.toJSONSchema("no", t.bigint);
+    }).toThrow();
+  });
+});
+
 describe("str", () => {
   test("converts to typescript", () => {
     expect(t.toTypescript(t.str)).toEqual("string");


### PR DESCRIPTION
Now that JS has a built-in bigint, we should have a primitive for it. Previously you could work around this via `.typeOf("bigint")`, but the `.typeOf` operator is meant to mostly be under-the-hood plumbing for the primitive types rather than actually used by end-users.