### PR TITLE
More accurate JSON schema generation

### DIFF
--- a/lib/to-jsonschema.ts
+++ b/lib/to-jsonschema.ts
@@ -43,6 +43,7 @@ export type JSONSchema = Annotated<{ type: "string" }>
                          properties: {
                            [key: string]: JSONSchema,
                          },
+                         additionalProperties?: false,
                        }>
                        | Annotated<{
                          type: "object",
@@ -237,10 +238,12 @@ function fromStruct(type: Struct<any>, options: Required<Options>): JSONSchema {
     }
   }
 
-  return {
+  const schema: JSONSchema = {
     type: 'object',
     required, properties,
   };
+  if(type.exact) schema.additionalProperties = false;
+  return schema;
 }
 
 function fromDict(type: Dict<any>, options: Required<Options>): JSONSchema {

--- a/test/to-jsonschema.ts
+++ b/test/to-jsonschema.ts
@@ -40,3 +40,32 @@ test("converts a whole bunch of types", () => {
     },
   });
 });
+
+test("exact structs emit closed object schemas", () => {
+  expect(t.toJSONSchema("user", t.exact({
+    name: t.str,
+  }))).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "user",
+    type: "object",
+    required: [ "name" ],
+    properties: {
+      name: { type: "string" },
+    },
+    additionalProperties: false,
+  });
+});
+
+test("subtype structs emit open object schemas", () => {
+  expect(t.toJSONSchema("user", t.subtype({
+    name: t.str,
+  }))).toEqual({
+    $schema: t.JSON_SCHEMA_VERSION,
+    title: "user",
+    type: "object",
+    required: [ "name" ],
+    properties: {
+      name: { type: "string" },
+    },
+  });
+});


### PR DESCRIPTION
Make sure exact types don't allow additional properties in JSON Schema