### PR TITLE
Better error messages

### DIFF
--- a/lib/checks/array.ts
+++ b/lib/checks/array.ts
@@ -1,4 +1,6 @@
 import { Err, Result } from "../result";
+import { at } from "../issue";
+import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
 import { Projection, TypeImpl } from "../type";
@@ -12,12 +14,14 @@ export class Arr<T> extends TypeImpl<Array<T>> {
   }
 
   check(val: any): Result<Array<T>> {
-    if(!Array.isArray(val)) return new Err(`${val} is not an array`);
+    if(!Array.isArray(val)) return new Err(typeMismatch("array", val));
 
-    for(const el of val) {
-      const result = this.elementType.check(el);
+    for(let index = 0; index < val.length; index++) {
+      const result = this.elementType.check(val[index]);
       // Don't bother collecting all errors in an array: for long arrays this is very obnoxious
-      if(result instanceof Err) return new Err(result.message);
+      if(result instanceof Err) {
+        return new Err(at({ kind: "array-element", index }, result.issue, "array"));
+      }
     }
 
     // If we got this far, there were no errors; it's an Array<T>
@@ -29,12 +33,14 @@ export class Arr<T> extends TypeImpl<Array<T>> {
    * validated. The default check-then-project flow would bypass a child's sliceResult override.
    */
   sliceResult(val: any): Result<Array<T>> {
-    if(!Array.isArray(val)) return new Err(`${val} is not an array`);
+    if(!Array.isArray(val)) return new Err(typeMismatch("array", val));
 
     const result: T[] = [];
-    for(const element of val) {
-      const sliced = this.elementType.sliceResult(element);
-      if(sliced instanceof Err) return sliced;
+    for(let index = 0; index < val.length; index++) {
+      const sliced = this.elementType.sliceResult(val[index]);
+      if(sliced instanceof Err) {
+        return new Err(at({ kind: "array-element", index }, sliced.issue, "array"));
+      }
       result.push(sliced);
     }
     return result;

--- a/lib/checks/instance-of.ts
+++ b/lib/checks/instance-of.ts
@@ -1,5 +1,12 @@
 import { Err, Result } from "../result";
+import { RuntimeType, runtimeTypeOf } from "../issues/shared";
 import { OpaqueType } from "../type";
+
+export type InstanceOfIssue = {
+  readonly kind: "instance-of";
+  readonly expectedClass: string | undefined;
+  readonly subject: RuntimeType;
+};
 
 export type Constructor<T> = Function & { prototype: T }
 
@@ -13,7 +20,11 @@ export class InstanceOf<T> extends OpaqueType<T> {
 
   check(val: any): Result<T> {
     if(val instanceof this.klass) return val as Result<T>;
-    return new Err(`${val} is not an instance of ${this.klass}`);
+    return new Err({
+      kind: "instance-of",
+      expectedClass: this.klass.name || undefined,
+      subject: runtimeTypeOf(val),
+    });
   }
 }
 

--- a/lib/checks/is.ts
+++ b/lib/checks/is.ts
@@ -1,5 +1,13 @@
 import { Err, Result } from "../result";
+import { RuntimeType, runtimeTypeOf } from "../issues/shared";
 import { OpaqueType } from "../type";
+
+export type GuardIssue = {
+  readonly kind: "guard";
+  readonly name: string;
+  readonly threw: boolean;
+  readonly subject: RuntimeType;
+};
 
 type Guard<T> = (val: any) => val is T
 
@@ -14,8 +22,22 @@ export class Is<T> extends OpaqueType<T> {
   }
 
   check(val: any): Result<T> {
-    if(this.isT(val)) return val;
-    return new Err(`${val} is not a ${this.name} (guard failed)`)
+    try {
+      if(this.isT(val)) return val;
+    } catch {
+      return new Err({
+        kind: "guard",
+        name: this.name,
+        threw: true,
+        subject: runtimeTypeOf(val),
+      });
+    }
+    return new Err({
+      kind: "guard",
+      name: this.name,
+      threw: false,
+      subject: runtimeTypeOf(val),
+    });
   }
 }
 

--- a/lib/checks/map.ts
+++ b/lib/checks/map.ts
@@ -1,4 +1,6 @@
 import { Err, Result } from "../result";
+import { at } from "../issue";
+import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
 import { Projection, TypeImpl } from "../type";
@@ -14,13 +16,19 @@ export class MapType<K, V> extends TypeImpl<Map<K, V>> {
   }
 
   check(val: any): Result<Map<K, V>> {
-    if(!(val instanceof Map)) return new Err(`${val} is not an instance of Map`);
+    if(!(val instanceof Map)) return new Err(typeMismatch("map", val));
 
-    for(const [k, v] of val) {
-      const kResult = this.keyType.check(k);
-      if(kResult instanceof Err) return new Err(`{val} key error: ${kResult.message}`);
-      const vResult = this.valueType.check(v);
-      if(vResult instanceof Err) return new Err(`{val} value error: ${vResult.message}`);
+    let index = 0;
+    for(const [key, value] of val) {
+      const keyResult = this.keyType.check(key);
+      if(keyResult instanceof Err) {
+        return new Err(at({ kind: "map-key", index }, keyResult.issue, "map"));
+      }
+      const valueResult = this.valueType.check(value);
+      if(valueResult instanceof Err) {
+        return new Err(at({ kind: "map-value", index }, valueResult.issue, "map"));
+      }
+      index += 1;
     }
 
     return val as Map<K, V>;
@@ -30,15 +38,21 @@ export class MapType<K, V> extends TypeImpl<Map<K, V>> {
    * Slice each captured entry in one pass so nested child sliceResult overrides are preserved.
    */
   sliceResult(val: any): Result<Map<K, V>> {
-    if(!(val instanceof Map)) return new Err(`${val} is not an instance of Map`);
+    if(!(val instanceof Map)) return new Err(typeMismatch("map", val));
 
     const result = new Map<K, V>();
+    let index = 0;
     for(const [key, value] of val) {
       const slicedKey = this.keyType.sliceResult(key);
-      if(slicedKey instanceof Err) return new Err(`{val} key error: ${slicedKey.message}`);
+      if(slicedKey instanceof Err) {
+        return new Err(at({ kind: "map-key", index }, slicedKey.issue, "map"));
+      }
       const slicedValue = this.valueType.sliceResult(value);
-      if(slicedValue instanceof Err) return new Err(`{val} value error: ${slicedValue.message}`);
+      if(slicedValue instanceof Err) {
+        return new Err(at({ kind: "map-value", index }, slicedValue.issue, "map"));
+      }
       result.set(slicedKey, slicedValue);
+      index += 1;
     }
     return result;
   }

--- a/lib/checks/never.ts
+++ b/lib/checks/never.ts
@@ -1,9 +1,15 @@
 import { Result, Err } from "../result";
+import { RuntimeType, runtimeTypeOf } from "../issues/shared";
 import { ConstraintType } from "../type";
 
+export type NeverIssue = {
+  readonly kind: "never";
+  readonly subject: RuntimeType;
+};
+
 export class Never extends ConstraintType<never> {
-  check(_: any): Result<never> {
-    return new Err('never')
+  check(val: any): Result<never> {
+    return new Err({ kind: "never", subject: runtimeTypeOf(val) });
   }
 }
 

--- a/lib/checks/set.ts
+++ b/lib/checks/set.ts
@@ -1,4 +1,6 @@
 import { Err, Result } from "../result";
+import { at } from "../issue";
+import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
 import { Projection, TypeImpl } from "../type";
@@ -12,10 +14,15 @@ export class SetType<V> extends TypeImpl<Set<V>> {
   }
 
   check(val: any): Result<Set<V>> {
-    if(!(val instanceof Set)) return new Err(`${val} is not an instance of Set`);
-    for(const v of val) {
-      const result = this.valueType.check(v);
-      if(result instanceof Err) return new Err(`{val} failed set check on value ${v}: ${result.message}`);
+    if(!(val instanceof Set)) return new Err(typeMismatch("set", val));
+
+    let index = 0;
+    for(const value of val) {
+      const result = this.valueType.check(value);
+      if(result instanceof Err) {
+        return new Err(at({ kind: "set-value", index }, result.issue, "set"));
+      }
+      index += 1;
     }
     return val as Set<V>;
   }
@@ -24,13 +31,17 @@ export class SetType<V> extends TypeImpl<Set<V>> {
    * Slice each captured value in one pass so nested child sliceResult overrides are preserved.
    */
   sliceResult(val: any): Result<Set<V>> {
-    if(!(val instanceof Set)) return new Err(`${val} is not an instance of Set`);
+    if(!(val instanceof Set)) return new Err(typeMismatch("set", val));
 
     const result = new Set<V>();
+    let index = 0;
     for(const value of val) {
       const sliced = this.valueType.sliceResult(value);
-      if(sliced instanceof Err) return sliced;
+      if(sliced instanceof Err) {
+        return new Err(at({ kind: "set-value", index }, sliced.issue, "set"));
+      }
       result.add(sliced);
+      index += 1;
     }
     return result;
   }

--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -1,4 +1,7 @@
 import { Err, Result } from "../result";
+import { at, multiple } from "../issue";
+import type { Issue } from "../issue";
+import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { Kind, TypedKind } from "../kind";
 import { Comment, Either, Intersection, Projection, Type, TypeImpl } from "../type";
@@ -47,6 +50,17 @@ type ObjectShape = {
   readonly rest?: TypedKind<any>;
 };
 
+export type MissingIssue = {
+  readonly kind: "missing";
+  readonly subject: "object";
+};
+
+export type UnknownPropertiesIssue = {
+  readonly kind: "unknown-properties";
+  readonly count: number;
+  readonly subject: "object";
+};
+
 abstract class MergeableType<T> extends TypeImpl<T> {
   constructor(protected readonly objectShape: ObjectShape) {
     super();
@@ -56,34 +70,56 @@ abstract class MergeableType<T> extends TypeImpl<T> {
     const typeErr = basicObjectErr(val, this.objectShape.requirePlainObject);
     if(typeErr) return typeErr;
 
-    const errs: string[] = [];
+    const issues: Issue[] = [];
     for(const prop of ownKeys(this.objectShape.fields)) {
       const field = this.objectShape.fields[prop];
       if(!(prop in val)) {
         if(field.allowsMissing) continue;
-        errs.push(`missing key '${String(prop)}'`);
+        issues.push(at(
+          { kind: "property", key: prop },
+          { kind: "missing", subject: "object" },
+          "object",
+        ));
         continue;
       }
 
       const result = field.checker.check(val[prop]);
-      if(result instanceof Err) errs.push(result.message);
+      if(result instanceof Err) {
+        issues.push(at({ kind: "property", key: prop }, result.issue, "object"));
+      }
     }
 
     const valueKeys = this.objectShape.exact ? enumerableOwnKeys(val) : Object.keys(val);
+    let dictionaryIndex = 0;
+    let unknownProperties = 0;
     for(const prop of valueKeys) {
       if(hasOwn(this.objectShape.fields, prop)) continue;
 
       if(this.objectShape.rest) {
         const result = this.objectShape.rest.check(val[prop]);
-        if(result instanceof Err) errs.push(`[${String(prop)}]: ${result.message}`);
+        if(result instanceof Err) {
+          issues.push(at(
+            { kind: "dictionary-value", index: dictionaryIndex },
+            result.issue,
+            "object",
+          ));
+        }
+        dictionaryIndex += 1;
       }
       else if(this.objectShape.exact) {
-        errs.push(`unknown key ${String(prop)}`);
+        unknownProperties += 1;
       }
     }
 
-    if(errs.length === 0) return val as T;
-    return new Err(`${val} failed the following checks:\n${errs.join('\n')}`);
+    if(unknownProperties > 0) {
+      issues.push({
+        kind: "unknown-properties",
+        count: unknownProperties,
+        subject: "object",
+      });
+    }
+    if(issues.length === 0) return val as T;
+    return new Err(multiple(issues, "object"));
   }
 
   /*
@@ -97,36 +133,58 @@ abstract class MergeableType<T> extends TypeImpl<T> {
     if(typeErr) return typeErr;
 
     const result: { [key: string]: any } = {};
-    const errs: string[] = [];
+    const issues: Issue[] = [];
     for(const prop of ownKeys(this.objectShape.fields)) {
       const field = this.objectShape.fields[prop];
       if(!(prop in val)) {
         if(field.allowsMissing) continue;
-        errs.push(`missing key '${String(prop)}'`);
+        issues.push(at(
+          { kind: "property", key: prop },
+          { kind: "missing", subject: "object" },
+          "object",
+        ));
         continue;
       }
 
       const sliced = field.checker.sliceResult(val[prop]);
-      if(sliced instanceof Err) errs.push(sliced.message);
+      if(sliced instanceof Err) {
+        issues.push(at({ kind: "property", key: prop }, sliced.issue, "object"));
+      }
       else setOwn(result, prop, sliced);
     }
 
     const valueKeys = this.objectShape.exact ? enumerableOwnKeys(val) : Object.keys(val);
+    let dictionaryIndex = 0;
+    let unknownProperties = 0;
     for(const prop of valueKeys) {
       if(hasOwn(this.objectShape.fields, prop)) continue;
 
       if(this.objectShape.rest) {
         const sliced = this.objectShape.rest.sliceResult(val[prop]);
-        if(sliced instanceof Err) errs.push(`[${String(prop)}]: ${sliced.message}`);
+        if(sliced instanceof Err) {
+          issues.push(at(
+            { kind: "dictionary-value", index: dictionaryIndex },
+            sliced.issue,
+            "object",
+          ));
+        }
         else setOwn(result, prop, sliced);
+        dictionaryIndex += 1;
       }
       else if(this.objectShape.exact) {
-        errs.push(`unknown key ${String(prop)}`);
+        unknownProperties += 1;
       }
     }
 
-    if(errs.length === 0) return result as T;
-    return new Err(`${val} failed the following checks:\n${errs.join('\n')}`);
+    if(unknownProperties > 0) {
+      issues.push({
+        kind: "unknown-properties",
+        count: unknownProperties,
+        subject: "object",
+      });
+    }
+    if(issues.length === 0) return result as T;
+    return new Err(multiple(issues, "object"));
   }
 
   protected merge<Incoming>(type: TypedKind<Incoming>): TypedKind<T & Incoming> | undefined {
@@ -180,8 +238,8 @@ function emptyObjectFields(): ObjectFields {
   return Object.create(null) as ObjectFields;
 }
 
-function ownKeys<T extends object>(value: T): Array<keyof T> {
-  return Reflect.ownKeys(value) as Array<keyof T>;
+function ownKeys<T extends object>(value: T): Array<Extract<keyof T, string | symbol>> {
+  return Reflect.ownKeys(value) as Array<Extract<keyof T, string | symbol>>;
 }
 
 function enumerableOwnKeys(value: object): PropertyKey[] {
@@ -204,13 +262,14 @@ function setOwn(target: object, key: PropertyKey, value: any): void {
 }
 
 function basicObjectErr<V>(val: any, requirePlainObject: boolean): Err<V> | undefined {
-  if(typeof val !== 'object') return new Err(`${val} is not an object`);
-  if(Array.isArray(val)) return new Err(`${val} is an array`);
-  if(val === null) return new Err(`${val} is null`);
+  const expected = requirePlainObject ? "dictionary" : "object";
+  if(typeof val !== "object" || Array.isArray(val) || val === null) {
+    return new Err(typeMismatch(expected, val));
+  }
   if(requirePlainObject) {
     const prototype = Object.getPrototypeOf(val);
     if(prototype !== Object.prototype && prototype !== null) {
-      return new Err(`${val} is not a dictionary`);
+      return new Err(typeMismatch("dictionary", val));
     }
   }
   return undefined;

--- a/lib/checks/type-of.ts
+++ b/lib/checks/type-of.ts
@@ -1,4 +1,5 @@
 import { Err, Result } from "../result";
+import { typeMismatch } from "../issues/shared";
 import { ConstraintType } from "../type";
 
 export type ValidTypeString = "undefined"
@@ -23,7 +24,7 @@ export class TypeOf<T> extends ConstraintType<T> {
     if(typeof val === this.typestring && (this.typestring !== "object" || val !== null)) {
       return val as T;
     }
-    return new Err(`${val} is not a ${this.typestring}`);
+    return new Err(typeMismatch(this.typestring, val));
   }
 }
 

--- a/lib/checks/value.ts
+++ b/lib/checks/value.ts
@@ -1,5 +1,17 @@
 import { Err, Result } from "../result";
+import {
+  LiteralExpectation,
+  literalExpectation,
+  RuntimeType,
+  runtimeTypeOf,
+} from "../issues/shared";
 import { Projection, UnmergeableType } from "../type";
+
+export type LiteralIssue = {
+  readonly kind: "literal";
+  readonly expected: LiteralExpectation;
+  readonly subject: RuntimeType;
+};
 
 export class Value<const T> extends UnmergeableType<T> {
   readonly val: T;
@@ -10,7 +22,11 @@ export class Value<const T> extends UnmergeableType<T> {
 
   check(val: any): Result<T> {
     if(val === this.val || (Number.isNaN(val) && Number.isNaN(this.val))) return val;
-    return new Err(`${val} is not equal to ${this.val}`);
+    return new Err({
+      kind: "literal",
+      expected: literalExpectation(this.val),
+      subject: runtimeTypeOf(val),
+    });
   }
 
   protected project(val: any): Projection<T> {

--- a/lib/format-issue.ts
+++ b/lib/format-issue.ts
@@ -5,15 +5,22 @@ import type {
   RuntimeType,
 } from "./issues/shared";
 
-export function formatIssue(issue: Issue, nestedErrorCount: number = Infinity): string {
-  validateNestedErrorCount(nestedErrorCount);
-  return format(issue, [], nestedErrorCount);
+export type FormatErrorOptions = {
+  readonly maxNestedErrors?: number;
+};
+
+export function formatIssue(issue: Issue, options: FormatErrorOptions = {}): string {
+  const maxNestedErrors = options.maxNestedErrors === undefined
+    ? Infinity
+    : options.maxNestedErrors;
+  validateMaxNestedErrors(maxNestedErrors);
+  return format(issue, [], maxNestedErrors);
 }
 
 function format(
   issue: Issue,
   path: ReadonlyArray<PathSegment>,
-  nestedErrorCount: number,
+  maxNestedErrors: number,
 ): string {
   switch(issue.kind) {
     case "type":
@@ -37,11 +44,11 @@ function format(
     case "never":
       return `${formatSubject(path, issue.subject)} cannot satisfy never`;
     case "at":
-      return format(issue.issue, [ ...path, ...issue.path ], nestedErrorCount);
+      return format(issue.issue, [ ...path, ...issue.path ], maxNestedErrors);
     case "multiple":
-      return issue.issues.map(child => format(child, path, nestedErrorCount)).join("\n");
+      return issue.issues.map(child => format(child, path, maxNestedErrors)).join("\n");
     case "union":
-      return formatUnion(issue.issues, path, issue.subject, nestedErrorCount);
+      return formatUnion(issue.issues, path, issue.subject, maxNestedErrors);
     default:
       return assertNever(issue);
   }
@@ -51,7 +58,7 @@ function formatUnion(
   issues: ReadonlyArray<Issue>,
   path: ReadonlyArray<PathSegment>,
   unionSubject: RuntimeType,
-  nestedErrorCount: number,
+  maxNestedErrors: number,
 ): string {
   const expectations = issues.map(issue => simpleExpectation(issue, path));
   if(expectations.every((value): value is SimpleExpectation => value !== undefined)) {
@@ -63,7 +70,7 @@ function formatUnion(
 
   const heading = unionHeading(formatSubject(path, unionSubject), issues.length);
   const branches = issues.map((issue, index) => {
-    const option = formatUnionOption(issue, path, nestedErrorCount);
+    const option = formatUnionOption(issue, path, maxNestedErrors);
     return indentBranch(`${index + 1}. `, option);
   });
   return [ heading, ...branches ].join("\n");
@@ -77,11 +84,11 @@ type NestedError = {
 function formatUnionOption(
   issue: Issue,
   path: ReadonlyArray<PathSegment>,
-  nestedErrorCount: number,
+  maxNestedErrors: number,
 ): string {
   const errors = nestedErrors(issue, path);
-  const visible = errors.slice(0, nestedErrorCount).map(error => {
-    return format(error.issue, error.path, nestedErrorCount);
+  const visible = errors.slice(0, maxNestedErrors).map(error => {
+    return format(error.issue, error.path, maxNestedErrors);
   });
   const omitted = errors.length - visible.length;
   if(omitted > 0) {
@@ -133,9 +140,9 @@ function simpleExpectation(
   return undefined;
 }
 
-function validateNestedErrorCount(value: number): void {
+function validateMaxNestedErrors(value: number): void {
   if(value !== Infinity && (!Number.isInteger(value) || value < 0)) {
-    throw new RangeError("nestedErrorCount must be a non-negative integer");
+    throw new RangeError("maxNestedErrors must be a non-negative integer");
   }
 }
 

--- a/lib/format-issue.ts
+++ b/lib/format-issue.ts
@@ -1,0 +1,218 @@
+import type { Issue, PathSegment } from "./issue";
+import type {
+  ExpectedType,
+  LiteralExpectation,
+  RuntimeType,
+} from "./issues/shared";
+
+export function formatIssue(issue: Issue): string {
+  return format(issue, []);
+}
+
+function format(issue: Issue, path: ReadonlyArray<PathSegment>): string {
+  switch(issue.kind) {
+    case "type":
+      return `${formatSubject(path, issue.subject)} is not ${expectedType(issue.expected)}`;
+    case "literal":
+      return `${formatSubject(path, issue.subject)} does not equal ${formatLiteral(issue.expected)}`;
+    case "instance-of":
+      return `${formatSubject(path, issue.subject)} is not an instance of ${issue.expectedClass || "the expected class"}`;
+    case "guard":
+      return issue.threw
+        ? `${formatSubject(path, issue.subject)} threw while checking guard ${quote(issue.name)}`
+        : `${formatSubject(path, issue.subject)} did not satisfy guard ${quote(issue.name)}`;
+    case "validation":
+      return issue.threw
+        ? `${formatSubject(path, issue.subject)} threw while checking validation ${quote(issue.description)}`
+        : `${formatSubject(path, issue.subject)} failed validation ${quote(issue.description)}`;
+    case "missing":
+      return `${formatSubject(path, issue.subject)} is missing`;
+    case "unknown-properties":
+      return `${formatSubject(path, issue.subject)} has ${count(issue.count, "unknown property", "unknown properties")}`;
+    case "never":
+      return `${formatSubject(path, issue.subject)} cannot satisfy never`;
+    case "at":
+      return format(issue.issue, [ ...path, ...issue.path ]);
+    case "multiple":
+      return issue.issues.map(child => format(child, path)).join("\n");
+    case "union":
+      return formatUnion(issue.issues, path, issue.subject);
+    default:
+      return assertNever(issue);
+  }
+}
+
+function formatUnion(
+  issues: ReadonlyArray<Issue>,
+  path: ReadonlyArray<PathSegment>,
+  unionSubject: RuntimeType,
+): string {
+  const expectations = issues.map(issue => simpleExpectation(issue, path));
+  if(expectations.every((value): value is SimpleExpectation => value !== undefined)) {
+    const first = expectations[0];
+    if(expectations.every(value => samePath(value.path, first.path) && value.subject === first.subject)) {
+      return `${formatSubject(first.path, first.subject)} is not ${list(expectations.map(value => value.expected))}`;
+    }
+  }
+
+  const heading = unionHeading(formatSubject(path, unionSubject), issues.length);
+  const branches = issues.map((issue, index) => {
+    return indentBranch(`${index + 1}. `, format(issue, path));
+  });
+  return [ heading, ...branches ].join("\n");
+}
+
+type SimpleExpectation = {
+  readonly path: ReadonlyArray<PathSegment>;
+  readonly subject: RuntimeType;
+  readonly expected: string;
+};
+
+function simpleExpectation(
+  issue: Issue,
+  path: ReadonlyArray<PathSegment>,
+): SimpleExpectation | undefined {
+  if(issue.kind === "at") {
+    return simpleExpectation(issue.issue, [ ...path, ...issue.path ]);
+  }
+  if(issue.kind === "type") {
+    return {
+      path,
+      subject: issue.subject,
+      expected: expectedType(issue.expected),
+    };
+  }
+  if(issue.kind === "literal" && issue.expected.kind === "null") {
+    return { path, subject: issue.subject, expected: "null" };
+  }
+  return undefined;
+}
+
+function unionHeading(value: string, optionCount: number): string {
+  if(optionCount === 1) {
+    return `${value} did not match the option in the schema. The option had errors. The errors for the option were:`;
+  }
+  return `${value} did not match any option in the schema. There were ${optionCount} options, and all options had errors. The errors for each option were:`;
+}
+
+function formatSubject(path: ReadonlyArray<PathSegment>, subject: RuntimeType): string {
+  if(path.length > 0) return formatPath(path);
+  return subject;
+}
+
+function formatPath(path: ReadonlyArray<PathSegment>): string {
+  let result = "";
+  for(const segment of path) {
+    switch(segment.kind) {
+      case "property":
+        result += formatProperty(segment.key);
+        break;
+      case "array-element":
+        result += `[${segment.index}]`;
+        break;
+      case "dictionary-value":
+        result += specialSegment(result, `${ordinal(segment.index + 1)} value in dictionary`);
+        break;
+      case "map-key":
+        result += specialSegment(result, `${ordinal(segment.index + 1)} key in map`);
+        break;
+      case "map-value":
+        result += specialSegment(result, `${ordinal(segment.index + 1)} value in map`);
+        break;
+      case "set-value":
+        result += specialSegment(result, `${ordinal(segment.index + 1)} value in set`);
+        break;
+      default:
+        assertNever(segment);
+    }
+  }
+  return result;
+}
+
+function formatProperty(key: string | symbol): string {
+  if(typeof key === "symbol") return `[${String(key)}]`;
+  if(/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)) return `.${key}`;
+  return `[${JSON.stringify(key)}]`;
+}
+
+function specialSegment(prefix: string, description: string): string {
+  return `${prefix.length > 0 ? "." : ""}<${description}>`;
+}
+
+function expectedType(type: ExpectedType): string {
+  if(type === "undefined") return "undefined";
+  const article = /^[aeiou]/.test(type) ? "an" : "a";
+  return `${article} ${type}`;
+}
+
+function formatLiteral(literal: LiteralExpectation): string {
+  switch(literal.kind) {
+    case "undefined":
+      return "undefined";
+    case "null":
+      return "null";
+    case "boolean":
+    case "number":
+      return String(literal.value);
+    case "bigint":
+      return `${literal.value}n`;
+    case "string":
+      return quote(literal.value);
+    case "opaque":
+      return `the expected ${literal.type} literal`;
+    default:
+      return assertNever(literal);
+  }
+}
+
+function quote(value: string): string {
+  return JSON.stringify(value);
+}
+
+function count(value: number, singular: string, plural: string): string {
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+function ordinal(value: number): string {
+  const lastTwoDigits = value % 100;
+  if(lastTwoDigits >= 11 && lastTwoDigits <= 13) return `${value}th`;
+
+  switch(value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
+function list(values: ReadonlyArray<string>): string {
+  if(values.length === 0) return "any expected type";
+  if(values.length === 1) return values[0];
+  if(values.length === 2) return `${values[0]} or ${values[1]}`;
+  return `${values.slice(0, -1).join(", ")}, or ${values[values.length - 1]}`;
+}
+
+function samePath(left: ReadonlyArray<PathSegment>, right: ReadonlyArray<PathSegment>): boolean {
+  if(left.length !== right.length) return false;
+  return left.every((segment, index) => {
+    const other = right[index];
+    if(segment.kind !== other.kind) return false;
+    if(segment.kind === "property" && other.kind === "property") return segment.key === other.key;
+    if("index" in segment && "index" in other) return segment.index === other.index;
+    return false;
+  });
+}
+
+function indentBranch(prefix: string, value: string): string {
+  const lines = value.split("\n");
+  const continuation = " ".repeat(prefix.length);
+  return `${prefix}${lines[0]}${lines.slice(1).map(line => `\n${continuation}${line}`).join("")}`;
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unknown issue variant: ${String(value)}`);
+}

--- a/lib/format-issue.ts
+++ b/lib/format-issue.ts
@@ -5,11 +5,16 @@ import type {
   RuntimeType,
 } from "./issues/shared";
 
-export function formatIssue(issue: Issue): string {
-  return format(issue, []);
+export function formatIssue(issue: Issue, nestedErrorCount: number = Infinity): string {
+  validateNestedErrorCount(nestedErrorCount);
+  return format(issue, [], nestedErrorCount);
 }
 
-function format(issue: Issue, path: ReadonlyArray<PathSegment>): string {
+function format(
+  issue: Issue,
+  path: ReadonlyArray<PathSegment>,
+  nestedErrorCount: number,
+): string {
   switch(issue.kind) {
     case "type":
       return `${formatSubject(path, issue.subject)} is not ${expectedType(issue.expected)}`;
@@ -32,11 +37,11 @@ function format(issue: Issue, path: ReadonlyArray<PathSegment>): string {
     case "never":
       return `${formatSubject(path, issue.subject)} cannot satisfy never`;
     case "at":
-      return format(issue.issue, [ ...path, ...issue.path ]);
+      return format(issue.issue, [ ...path, ...issue.path ], nestedErrorCount);
     case "multiple":
-      return issue.issues.map(child => format(child, path)).join("\n");
+      return issue.issues.map(child => format(child, path, nestedErrorCount)).join("\n");
     case "union":
-      return formatUnion(issue.issues, path, issue.subject);
+      return formatUnion(issue.issues, path, issue.subject, nestedErrorCount);
     default:
       return assertNever(issue);
   }
@@ -46,6 +51,7 @@ function formatUnion(
   issues: ReadonlyArray<Issue>,
   path: ReadonlyArray<PathSegment>,
   unionSubject: RuntimeType,
+  nestedErrorCount: number,
 ): string {
   const expectations = issues.map(issue => simpleExpectation(issue, path));
   if(expectations.every((value): value is SimpleExpectation => value !== undefined)) {
@@ -57,9 +63,48 @@ function formatUnion(
 
   const heading = unionHeading(formatSubject(path, unionSubject), issues.length);
   const branches = issues.map((issue, index) => {
-    return indentBranch(`${index + 1}. `, format(issue, path));
+    const option = formatUnionOption(issue, path, nestedErrorCount);
+    return indentBranch(`${index + 1}. `, option);
   });
   return [ heading, ...branches ].join("\n");
+}
+
+type NestedError = {
+  readonly issue: Issue;
+  readonly path: ReadonlyArray<PathSegment>;
+};
+
+function formatUnionOption(
+  issue: Issue,
+  path: ReadonlyArray<PathSegment>,
+  nestedErrorCount: number,
+): string {
+  const errors = nestedErrors(issue, path);
+  const visible = errors.slice(0, nestedErrorCount).map(error => {
+    return format(error.issue, error.path, nestedErrorCount);
+  });
+  const omitted = errors.length - visible.length;
+  if(omitted > 0) {
+    visible.push(`... ${count(omitted, "more error", "more errors")} omitted for this option.`);
+  }
+  return visible.join("\n");
+}
+
+function nestedErrors(
+  issue: Issue,
+  path: ReadonlyArray<PathSegment>,
+): NestedError[] {
+  if(issue.kind === "at") {
+    return nestedErrors(issue.issue, [ ...path, ...issue.path ]);
+  }
+  if(issue.kind === "multiple") {
+    let errors: NestedError[] = [];
+    for(const child of issue.issues) {
+      errors = errors.concat(nestedErrors(child, path));
+    }
+    return errors;
+  }
+  return [ { issue, path } ];
 }
 
 type SimpleExpectation = {
@@ -86,6 +131,12 @@ function simpleExpectation(
     return { path, subject: issue.subject, expected: "null" };
   }
   return undefined;
+}
+
+function validateNestedErrorCount(value: number): void {
+  if(value !== Infinity && (!Number.isInteger(value) || value < 0)) {
+    throw new RangeError("nestedErrorCount must be a non-negative integer");
+  }
 }
 
 function unionHeading(value: string, optionCount: number): string {

--- a/lib/issue.ts
+++ b/lib/issue.ts
@@ -1,0 +1,80 @@
+import type { InstanceOfIssue } from "./checks/instance-of";
+import type { GuardIssue } from "./checks/is";
+import type { NeverIssue } from "./checks/never";
+import type { MissingIssue, UnknownPropertiesIssue } from "./checks/struct";
+import type { LiteralIssue } from "./checks/value";
+import type { RuntimeType, TypeMismatchIssue } from "./issues/shared";
+import type { ValidationIssue } from "./type";
+
+export type LeafIssue =
+  | TypeMismatchIssue
+  | LiteralIssue
+  | InstanceOfIssue
+  | GuardIssue
+  | ValidationIssue
+  | MissingIssue
+  | UnknownPropertiesIssue
+  | NeverIssue;
+
+export type PathSegment =
+  | { readonly kind: "property", readonly key: string | symbol }
+  | { readonly kind: "array-element", readonly index: number }
+  | { readonly kind: "dictionary-value", readonly index: number }
+  | { readonly kind: "map-key", readonly index: number }
+  | { readonly kind: "map-value", readonly index: number }
+  | { readonly kind: "set-value", readonly index: number };
+
+export type AtIssue = {
+  readonly kind: "at";
+  readonly subject: RuntimeType;
+  readonly path: ReadonlyArray<PathSegment>;
+  readonly issue: Issue;
+};
+
+export type MultipleIssue = {
+  readonly kind: "multiple";
+  readonly subject: RuntimeType;
+  readonly issues: ReadonlyArray<Issue>;
+};
+
+export type UnionIssue = {
+  readonly kind: "union";
+  readonly subject: RuntimeType;
+  readonly issues: ReadonlyArray<Issue>;
+};
+
+export type Issue = LeafIssue | AtIssue | MultipleIssue | UnionIssue;
+
+export function at(segment: PathSegment, issue: Issue, subject: RuntimeType): AtIssue {
+  if(issue.kind === "at") {
+    return {
+      kind: "at",
+      subject,
+      path: [ segment, ...issue.path ],
+      issue: issue.issue,
+    };
+  }
+
+  return { kind: "at", subject, path: [ segment ], issue };
+}
+
+export function multiple(issues: ReadonlyArray<Issue>, subject: RuntimeType): Issue {
+  const flattened: Issue[] = [];
+  for(const issue of issues) {
+    if(issue.kind === "multiple") flattened.push(...issue.issues);
+    else flattened.push(issue);
+  }
+
+  if(flattened.length === 1) return flattened[0];
+  return { kind: "multiple", subject, issues: flattened };
+}
+
+export function union(issues: ReadonlyArray<Issue>, subject: RuntimeType): UnionIssue {
+  const flattened: Issue[] = [];
+  for(const issue of issues) {
+    if(issue.kind === "union") flattened.push(...issue.issues);
+    else flattened.push(issue);
+  }
+
+  return { kind: "union", subject, issues: flattened };
+}

--- a/lib/issues/shared.ts
+++ b/lib/issues/shared.ts
@@ -1,0 +1,65 @@
+export type RuntimeType =
+  | "undefined"
+  | "null"
+  | "boolean"
+  | "number"
+  | "bigint"
+  | "string"
+  | "symbol"
+  | "function"
+  | "array"
+  | "map"
+  | "set"
+  | "object";
+
+export type ExpectedType = RuntimeType | "dictionary";
+
+export type TypeMismatchIssue = {
+  readonly kind: "type";
+  readonly expected: ExpectedType;
+  readonly subject: RuntimeType;
+};
+
+export type LiteralExpectation =
+  | { readonly kind: "undefined" }
+  | { readonly kind: "null" }
+  | { readonly kind: "boolean", readonly value: boolean }
+  | { readonly kind: "number", readonly value: number }
+  | { readonly kind: "bigint", readonly value: string }
+  | { readonly kind: "string", readonly value: string }
+  | { readonly kind: "opaque", readonly type: RuntimeType };
+
+export function runtimeTypeOf(value: unknown): RuntimeType {
+  if(value === null) return "null";
+  if(Array.isArray(value)) return "array";
+  if(value instanceof Map) return "map";
+  if(value instanceof Set) return "set";
+  return typeof value;
+}
+
+export function typeMismatch(expected: ExpectedType, value: unknown): TypeMismatchIssue {
+  return {
+    kind: "type",
+    expected,
+    subject: runtimeTypeOf(value),
+  };
+}
+
+export function literalExpectation(value: unknown): LiteralExpectation {
+  if(value === null) return { kind: "null" };
+
+  switch(typeof value) {
+    case "undefined":
+      return { kind: "undefined" };
+    case "boolean":
+      return { kind: "boolean", value };
+    case "number":
+      return { kind: "number", value };
+    case "bigint":
+      return { kind: "bigint", value: value.toString() };
+    case "string":
+      return { kind: "string", value };
+    default:
+      return { kind: "opaque", type: runtimeTypeOf(value) };
+  }
+}

--- a/lib/result.ts
+++ b/lib/result.ts
@@ -1,4 +1,4 @@
-import { formatIssue } from "./format-issue";
+import { formatIssue, FormatErrorOptions } from "./format-issue";
 import type { Issue } from "./issue";
 
 export class TypeError extends Error {
@@ -7,8 +7,8 @@ export class TypeError extends Error {
     this.name = this.constructor.name;
   }
 
-  formatError(nestedErrorCount: number): string {
-    return formatIssue(this.issue, nestedErrorCount);
+  formatError(options: FormatErrorOptions = {}): string {
+    return formatIssue(this.issue, options);
   }
 }
 
@@ -19,8 +19,8 @@ export class Err<_> {
     this.message = formatIssue(issue);
   }
 
-  formatError(nestedErrorCount: number): string {
-    return formatIssue(this.issue, nestedErrorCount);
+  formatError(options: FormatErrorOptions = {}): string {
+    return formatIssue(this.issue, options);
   }
 
   toError(): TypeError {

--- a/lib/result.ts
+++ b/lib/result.ts
@@ -1,18 +1,22 @@
+import { formatIssue } from "./format-issue";
+import type { Issue } from "./issue";
+
 export class TypeError extends Error {
-  constructor(message: string) {
+  constructor(readonly issue: Issue, message: string) {
     super(message);
     this.name = this.constructor.name;
   }
 }
 
 export class Err<_> {
-  message: string;
-  constructor(str: string) {
-    this.message = str;
+  readonly message: string;
+
+  constructor(readonly issue: Issue) {
+    this.message = formatIssue(issue);
   }
 
-  toError() {
-    return new TypeError(this.message);
+  toError(): TypeError {
+    return new TypeError(this.issue, this.message);
   }
 }
 

--- a/lib/result.ts
+++ b/lib/result.ts
@@ -6,6 +6,10 @@ export class TypeError extends Error {
     super(message);
     this.name = this.constructor.name;
   }
+
+  formatError(nestedErrorCount: number): string {
+    return formatIssue(this.issue, nestedErrorCount);
+  }
 }
 
 export class Err<_> {
@@ -13,6 +17,10 @@ export class Err<_> {
 
   constructor(readonly issue: Issue) {
     this.message = formatIssue(issue);
+  }
+
+  formatError(nestedErrorCount: number): string {
+    return formatIssue(this.issue, nestedErrorCount);
   }
 
   toError(): TypeError {

--- a/lib/t.ts
+++ b/lib/t.ts
@@ -17,6 +17,9 @@
  */
 
 export * from "./result";
+export * from "./issue";
+export * from "./format-issue";
+export * from "./issues/shared";
 export * from "./type";
 export * from "./get-type";
 

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -1,4 +1,6 @@
 import { Err, Result } from "./result";
+import { union } from "./issue";
+import { RuntimeType, runtimeTypeOf } from "./issues/shared";
 import { asKind } from "./as-kind";
 import type { Kind, TypedKind } from "./kind";
 
@@ -216,6 +218,13 @@ export class Comment<T> extends TypeImpl<T> {
 
 export type Validator<T> = (val: T) => boolean;
 
+export type ValidationIssue = {
+  readonly kind: "validation";
+  readonly description: string;
+  readonly threw: boolean;
+  readonly subject: RuntimeType;
+};
+
 export class Validation<T> extends ConstraintType<T> {
   readonly desc: string;
   readonly validator: Validator<T>;
@@ -229,11 +238,21 @@ export class Validation<T> extends ConstraintType<T> {
   check(val: any): Result<T> {
     try {
       if(this.validator(val)) return val;
-    } catch(e) {
-      return new Err(`Validation \`${this.desc}\` threw an error: ${e}`);
+    } catch {
+      return new Err({
+        kind: "validation",
+        description: this.desc,
+        threw: true,
+        subject: runtimeTypeOf(val),
+      });
     }
 
-    return new Err(`Failed validation: ${this.desc}`);
+    return new Err({
+      kind: "validation",
+      description: this.desc,
+      threw: false,
+      subject: runtimeTypeOf(val),
+    });
   }
 }
 
@@ -261,7 +280,7 @@ export class Either<L, R> extends TypeImpl<L|R> {
     if(!(l instanceof Err)) return l;
     const r = this.r.check(val);
     if(!(r instanceof Err)) return r;
-    return new Err(`${val} failed the following checks:\n${l.message}\n${r.message}`);
+    return new Err(union([ l.issue, r.issue ], runtimeTypeOf(val)));
   }
 
   /*
@@ -273,7 +292,7 @@ export class Either<L, R> extends TypeImpl<L|R> {
     if(!(l instanceof Err)) return l;
     const r = this.r.sliceResult(val);
     if(!(r instanceof Err)) return r;
-    return new Err(`${val} failed the following checks:\n${l.message}\n${r.message}`);
+    return new Err(union([ l.issue, r.issue ], runtimeTypeOf(val)));
   }
 
   protected merge<Incoming>(type: TypedKind<Incoming>): TypedKind<(L|R) & Incoming> {

--- a/test/error.ts
+++ b/test/error.ts
@@ -1,0 +1,427 @@
+import { describe, expect, test } from "vitest";
+import * as t from "../index";
+
+function errorOf<T>(result: t.Result<T>): t.Err<T> {
+  expect(result).toBeInstanceOf(t.Err);
+  if(!(result instanceof t.Err)) throw new Error("Expected check to fail");
+  return result;
+}
+
+describe("structured issues", () => {
+  test("keeps message as a formatted string data property", () => {
+    const error = errorOf(t.str.check(5));
+    const descriptor = Object.getOwnPropertyDescriptor(error, "message");
+
+    expect(descriptor && descriptor.get).toBeUndefined();
+    expect(descriptor && descriptor.value).toBe("number is not a string");
+    expect(error.message).toBe(t.formatIssue(error.issue));
+  });
+
+  test("preserves the issue and formatted message when converting to TypeError", () => {
+    const result = errorOf(t.str.check(5));
+    const error = result.toError();
+
+    expect(error).toBeInstanceOf(t.TypeError);
+    expect(error.issue).toBe(result.issue);
+    expect(error.message).toBe(result.message);
+  });
+
+  test("exposes a structured nested issue", () => {
+    const error = errorOf(t.subtype({ age: t.num }).check({ age: "private" }));
+
+    expect(error.issue).toEqual({
+      kind: "at",
+      subject: "object",
+      path: [ { kind: "property", key: "age" } ],
+      issue: {
+        kind: "type",
+        expected: "number",
+        subject: "string",
+      },
+    });
+  });
+
+  test("uses the inspected object as the subject of a missing property", () => {
+    const error = errorOf(t.subtype({ name: t.str }).check({}));
+
+    expect(error.issue).toEqual({
+      kind: "at",
+      subject: "object",
+      path: [ { kind: "property", key: "name" } ],
+      issue: {
+        kind: "missing",
+        subject: "object",
+      },
+    });
+    expect(error.message).toBe(".name is missing");
+  });
+});
+
+describe("issue formatting", () => {
+  test("formats nested properties and sibling failures", () => {
+    const type = t.subtype({
+      name: t.str,
+      profile: t.subtype({ age: t.num }),
+      email: t.str,
+    });
+    const error = errorOf(type.check({
+      name: 5,
+      profile: { age: "private" },
+    }));
+
+    expect(error.message).toBe([
+      ".name is not a string",
+      ".profile.age is not a number",
+      ".email is missing",
+    ].join("\n"));
+  });
+
+  test("formats property names that require bracket notation", () => {
+    const error = errorOf(t.subtype({
+      "not-valid": t.str,
+    }).check({ "not-valid": 5 }));
+
+    expect(error.message).toBe("[\"not-valid\"] is not a string");
+  });
+
+  test("formats array indexes", () => {
+    const type = t.subtype({
+      users: t.array(t.subtype({ name: t.str })),
+    });
+    const error = errorOf(type.check({
+      users: [ { name: "valid" }, { name: 5 } ],
+    }));
+
+    expect(error.message).toBe(".users[1].name is not a string");
+  });
+
+  test("formats map keys and values by entry position", () => {
+    const keyError = errorOf(t.map(t.num, t.str).check(new Map([[ "private", "value" ]])));
+    const valueError = errorOf(t.map(t.str, t.subtype({ id: t.num })).check(
+      new Map([[ "private", { id: "private" } ]]),
+    ));
+
+    expect(keyError.message).toBe("<1st key in map> is not a number");
+    expect(valueError.message).toBe("<1st value in map>.id is not a number");
+  });
+
+  test("formats ordinal suffixes through 23rd", () => {
+    const ordinals = [
+      "1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th",
+      "11th", "12th", "13th", "14th", "15th", "16th", "17th", "18th", "19th", "20th",
+      "21st", "22nd", "23rd",
+    ];
+
+    const messages = ordinals.map((_, index) => t.formatIssue({
+      kind: "at",
+      subject: "map",
+      path: [ { kind: "map-key", index } ],
+      issue: { kind: "type", expected: "number", subject: "string" },
+    }));
+
+    expect(messages).toEqual(ordinals.map(value => `<${value} key in map> is not a number`));
+  });
+
+  test("formats set values by iteration position", () => {
+    const error = errorOf(t.set(t.subtype({ id: t.num })).check(
+      new Set([{ id: "private" }]),
+    ));
+
+    expect(error.message).toBe("<1st value in set>.id is not a number");
+  });
+
+  test("does not render dictionary or unknown property names", () => {
+    const dictionaryError = errorOf(t.subtype({
+      settings: t.dict(t.num),
+    }).check({ settings: { "private-key": "private" } }));
+    const exactError = errorOf(t.subtype({
+      profile: t.exact({}),
+    }).check({ profile: { "private-one": 1, "private-two": 2 } }));
+
+    expect(dictionaryError.message).toBe(".settings.<1st value in dictionary> is not a number");
+    expect(exactError.message).toBe(".profile has 2 unknown properties");
+  });
+
+  test("condenses simple union failures", () => {
+    const error = errorOf(t.num.or(t.str).or(t.nil).check(false));
+
+    expect(error.message).toBe("boolean is not a number, a string, or null");
+  });
+
+  test("preserves structural union branches", () => {
+    const type = t.subtype({
+      kind: t.value("cat"),
+      lives: t.num,
+    }).or(t.subtype({
+      kind: t.value("dog"),
+      good: t.bool,
+    }));
+    const error = errorOf(type.check({ kind: "bird" }));
+
+    expect(error.message).toBe([
+      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. .kind does not equal \"cat\"",
+      "   .lives is missing",
+      "2. .kind does not equal \"dog\"",
+      "   .good is missing",
+    ].join("\n"));
+  });
+
+  test("formats merged structural intersections", () => {
+    const type = t.subtype({
+      profile: t.subtype({
+        name: t.str,
+      }),
+    }).and(t.subtype({
+      profile: t.subtype({
+        age: t.num,
+      }),
+      enabled: t.bool,
+    }));
+    const error = errorOf(type.check({
+      profile: {
+        name: 5,
+        age: "private",
+      },
+      enabled: "private",
+    }));
+
+    expect(error.message).toBe([
+      ".profile.name is not a string",
+      ".profile.age is not a number",
+      ".enabled is not a boolean",
+    ].join("\n"));
+  });
+
+  test("formats structural unions nested inside intersections", () => {
+    const base = t.subtype({
+      payload: t.subtype({
+        id: t.str,
+      }),
+    });
+    const variant = t.subtype({
+      payload: t.subtype({
+        email: t.str,
+      }).or(t.subtype({
+        phone: t.str,
+      })),
+    });
+    const error = errorOf(base.and(variant).check({
+      payload: {
+        id: 5,
+        email: 6,
+        phone: 7,
+      },
+    }));
+
+    expect(error.message).toBe([
+      ".payload did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. .payload.email is not a string",
+      "   .payload.id is not a string",
+      "2. .payload.phone is not a string",
+      "   .payload.id is not a string",
+    ].join("\n"));
+  });
+
+  test("formats intersections distributed across structural unions", () => {
+    const metadata = t.subtype({
+      meta: t.subtype({
+        requestId: t.str,
+      }),
+    });
+    const userEvent = t.subtype({
+      kind: t.value("user"),
+      payload: t.subtype({
+        id: t.str,
+      }).and(t.subtype({
+        email: t.str,
+      })),
+    });
+    const teamEvent = t.subtype({
+      kind: t.value("team"),
+      payload: t.subtype({
+        id: t.num,
+      }).and(t.subtype({
+        members: t.array(t.str),
+      })),
+    });
+    const event = metadata.and(userEvent.or(teamEvent));
+    const error = errorOf(event.check({
+      kind: "other",
+      payload: {
+        id: false,
+        members: [ 1 ],
+      },
+      meta: {
+        requestId: 5,
+      },
+    }));
+
+    expect(error.message).toBe([
+      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. .kind does not equal \"user\"",
+      "   .payload.id is not a string",
+      "   .payload.email is missing",
+      "   .meta.requestId is not a string",
+      "2. .kind does not equal \"team\"",
+      "   .payload.id is not a number",
+      "   .payload.members[0] is not a string",
+      "   .meta.requestId is not a string",
+    ].join("\n"));
+  });
+});
+
+describe("discriminated structural unions", () => {
+  const SomeData = t.subtype({
+    user: t.subtype({
+      id: t.str,
+      displayName: t.str,
+    }),
+    permissions: t.array(t.str),
+  });
+  const Response = t.subtype({
+    type: t.value("error"),
+    error: t.str,
+  }).or(t.subtype({
+    type: t.value("success"),
+    data: SomeData,
+  }));
+
+  test("accepts both members that share a discriminant key", () => {
+    const failed = {
+      type: "error" as const,
+      error: "Something went wrong",
+    };
+    const succeeded = {
+      type: "success" as const,
+      data: {
+        user: {
+          id: "user-1",
+          displayName: "Matt",
+        },
+        permissions: [ "read", "write" ],
+      },
+    };
+
+    expect(Response.check(failed)).not.toBeInstanceOf(t.Err);
+    expect(Response.check(succeeded)).not.toBeInstanceOf(t.Err);
+    expect(Response.assert(failed)).toBe(failed);
+    expect(Response.assert(succeeded)).toBe(succeeded);
+  });
+
+  test("slices using the successful discriminated member", () => {
+    const result = Response.slice({
+      type: "success",
+      data: {
+        user: {
+          id: "user-1",
+          displayName: "Matt",
+          privateExtra: "removed",
+        },
+        permissions: [ "read" ],
+        privateExtra: "removed",
+      },
+      privateExtra: "removed",
+    });
+
+    expect(result).toEqual({
+      type: "success",
+      data: {
+        user: {
+          id: "user-1",
+          displayName: "Matt",
+        },
+        permissions: [ "read" ],
+      },
+    });
+  });
+
+  test("explains every member when the discriminant matches neither", () => {
+    const error = errorOf(Response.check({
+      type: "pending",
+    }));
+
+    expect(error.message).toBe([
+      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. .type does not equal \"error\"",
+      "   .error is missing",
+      "2. .type does not equal \"success\"",
+      "   .data is missing",
+    ].join("\n"));
+  });
+
+  test("explains nested data errors when the discriminant matches", () => {
+    const error = errorOf(Response.check({
+      type: "success",
+      data: {
+        user: {
+          id: 5,
+        },
+        permissions: [ "read", false ],
+      },
+    }));
+
+    expect(error.message).toBe([
+      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. .type does not equal \"error\"",
+      "   .error is missing",
+      "2. .data.user.id is not a string",
+      "   .data.user.displayName is missing",
+      "   .data.permissions[1] is not a string",
+    ].join("\n"));
+  });
+});
+
+describe("error privacy", () => {
+  const secret = "VERY_SECRET_VALUE";
+
+  function expectSecretAbsent(type: t.Type<any>, value: unknown): void {
+    const error = errorOf(type.check(value));
+    const thrown = error.toError();
+
+    expect(error.message).not.toContain(secret);
+    expect(thrown.message).not.toContain(secret);
+    expect(JSON.stringify(error.issue)).not.toContain(secret);
+  }
+
+  test("does not retain or render rejected values", () => {
+    expectSecretAbsent(t.num, secret);
+    expectSecretAbsent(t.subtype({ token: t.num }), { token: secret });
+    expectSecretAbsent(t.array(t.num), [ secret ]);
+    expectSecretAbsent(t.map(t.num, t.num), new Map([[ secret, 1 ]]));
+    expectSecretAbsent(t.map(t.num, t.num), new Map([[ 1, secret ]]));
+    expectSecretAbsent(t.set(t.num), new Set([ secret ]));
+    expectSecretAbsent(t.num.or(t.bool), secret);
+  });
+
+  test("does not retain or render input-derived property names", () => {
+    expectSecretAbsent(t.dict(t.num), { [secret]: secret });
+    expectSecretAbsent(t.exact({}), { [secret]: true });
+  });
+
+  test("does not retain or render exceptions thrown by callbacks", () => {
+    expectSecretAbsent(t.num.validate("safe description", () => {
+      throw new Error(secret);
+    }), 1);
+    expectSecretAbsent(t.is("safe guard", (_: unknown): _ is true => {
+      throw new Error(secret);
+    }), true);
+  });
+
+  test("does not coerce rejected objects while creating errors", () => {
+    const input = {
+      toString(): string {
+        throw new Error("toString called");
+      },
+      valueOf(): never {
+        throw new Error("valueOf called");
+      },
+      [Symbol.toPrimitive](): never {
+        throw new Error("Symbol.toPrimitive called");
+      },
+    };
+
+    const error = errorOf(t.str.check(input));
+    expect(error.message).toBe("object is not a string");
+  });
+});

--- a/test/error.ts
+++ b/test/error.ts
@@ -271,6 +271,97 @@ describe("issue formatting", () => {
   });
 });
 
+describe("limited union error formatting", () => {
+  const ManyErrors = t.subtype({
+    data: t.subtype({
+      one: t.str,
+      two: t.str,
+      three: t.str,
+      four: t.str,
+      five: t.str,
+      six: t.str,
+      seven: t.str,
+      eight: t.str,
+      nine: t.str,
+      ten: t.str,
+    }),
+  });
+  const TwoErrors = t.subtype({
+    left: t.str,
+    right: t.str,
+  });
+  function manyErrors(): t.Err<any> {
+    return errorOf(ManyErrors.or(TwoErrors).check({ data: {} }));
+  }
+
+  test("limits nested errors independently for each option", () => {
+    expect(manyErrors().formatError(2)).toBe([
+      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. .data.one is missing",
+      "   .data.two is missing",
+      "   ... 8 more errors omitted for this option.",
+      "2. .left is missing",
+      "   .right is missing",
+    ].join("\n"));
+  });
+
+  test("keeps message fully formatted", () => {
+    const error = manyErrors();
+
+    expect(error.message).toContain(".data.one is missing");
+    expect(error.message).toContain(".data.ten is missing");
+    expect(error.message).toContain(".left is missing");
+    expect(error.message).toContain(".right is missing");
+    expect(error.message).not.toContain("omitted");
+  });
+
+  test("formats Err and TypeError identically", () => {
+    const error = manyErrors();
+    const thrown = error.toError();
+
+    expect(thrown.formatError(2)).toBe(error.formatError(2));
+    expect(thrown.message).toBe(error.message);
+  });
+
+  test("supports hiding every nested error", () => {
+    expect(manyErrors().formatError(0)).toBe([
+      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. ... 10 more errors omitted for this option.",
+      "2. ... 2 more errors omitted for this option.",
+    ].join("\n"));
+  });
+
+  test("rejects invalid nested error counts", () => {
+    const error = manyErrors();
+
+    for(const count of [ -1, 1.5, NaN ]) {
+      expect(() => error.formatError(count)).toThrow(RangeError);
+      expect(() => error.toError().formatError(count)).toThrow(RangeError);
+    }
+  });
+
+  test("limits options in a union nested beneath a property", () => {
+    const type = t.subtype({
+      payload: t.subtype({
+        one: t.str,
+        two: t.str,
+      }).or(t.subtype({
+        three: t.str,
+        four: t.str,
+      })),
+    });
+    const nested = errorOf(type.check({ payload: {} }));
+
+    expect(nested.formatError(1)).toBe([
+      ".payload did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
+      "1. .payload.one is missing",
+      "   ... 1 more error omitted for this option.",
+      "2. .payload.three is missing",
+      "   ... 1 more error omitted for this option.",
+    ].join("\n"));
+  });
+});
+
 describe("discriminated structural unions", () => {
   const SomeData = t.subtype({
     user: t.subtype({

--- a/test/error.ts
+++ b/test/error.ts
@@ -295,7 +295,7 @@ describe("limited union error formatting", () => {
   }
 
   test("limits nested errors independently for each option", () => {
-    expect(manyErrors().formatError(2)).toBe([
+    expect(manyErrors().formatError({ maxNestedErrors: 2 })).toBe([
       "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
       "1. .data.one is missing",
       "   .data.two is missing",
@@ -308,6 +308,8 @@ describe("limited union error formatting", () => {
   test("keeps message fully formatted", () => {
     const error = manyErrors();
 
+    expect(error.formatError()).toBe(error.message);
+    expect(error.formatError({})).toBe(error.message);
     expect(error.message).toContain(".data.one is missing");
     expect(error.message).toContain(".data.ten is missing");
     expect(error.message).toContain(".left is missing");
@@ -319,12 +321,12 @@ describe("limited union error formatting", () => {
     const error = manyErrors();
     const thrown = error.toError();
 
-    expect(thrown.formatError(2)).toBe(error.formatError(2));
+    expect(thrown.formatError({ maxNestedErrors: 2 })).toBe(error.formatError({ maxNestedErrors: 2 }));
     expect(thrown.message).toBe(error.message);
   });
 
   test("supports hiding every nested error", () => {
-    expect(manyErrors().formatError(0)).toBe([
+    expect(manyErrors().formatError({ maxNestedErrors: 0 })).toBe([
       "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
       "1. ... 10 more errors omitted for this option.",
       "2. ... 2 more errors omitted for this option.",
@@ -335,8 +337,8 @@ describe("limited union error formatting", () => {
     const error = manyErrors();
 
     for(const count of [ -1, 1.5, NaN ]) {
-      expect(() => error.formatError(count)).toThrow(RangeError);
-      expect(() => error.toError().formatError(count)).toThrow(RangeError);
+      expect(() => error.formatError({ maxNestedErrors: count })).toThrow(RangeError);
+      expect(() => error.toError().formatError({ maxNestedErrors: count })).toThrow(RangeError);
     }
   });
 
@@ -352,7 +354,7 @@ describe("limited union error formatting", () => {
     });
     const nested = errorOf(type.check({ payload: {} }));
 
-    expect(nested.formatError(1)).toBe([
+    expect(nested.formatError({ maxNestedErrors: 1 })).toBe([
       ".payload did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
       "1. .payload.one is missing",
       "   ... 1 more error omitted for this option.",


### PR DESCRIPTION
I think this illustrates it pretty well:

```typescript
  const SomeData = t.subtype({
    user: t.subtype({
      id: t.str,
      displayName: t.str,
    }),
    permissions: t.array(t.str),
  });
  const Response = t.subtype({
    type: t.value("error"),
    error: t.str,
  }).or(t.subtype({
    type: t.value("success"),
    data: SomeData,
  }));
```

```typescript
    const error = errorOf(Response.check({
      type: "success",
      data: {
        user: {
          id: 5,
        },
        permissions: [ "read", false ],
      },
    }));

    expect(error.message).toBe([
      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
      "1. .type does not equal \"error\"",
      "   .error is missing",
      "2. .data.user.id is not a string",
      "   .data.user.displayName is missing",
      "   .data.permissions[1] is not a string",
    ].join("\n"));
```

And for large schemas, there are optional formatting options so you don't send down 8 million key errors when you have a few things unioned together and one is off by one and another is off by a hundred:

```typescript
  const ManyErrors = t.subtype({
    data: t.subtype({
      one: t.str,
      two: t.str,
      three: t.str,
      four: t.str,
      five: t.str,
      six: t.str,
      seven: t.str,
      eight: t.str,
      nine: t.str,
      ten: t.str,
    }),
  });
  const TwoErrors = t.subtype({
    left: t.str,
    right: t.str,
  });
  function manyErrors(): t.Err<any> {
    return errorOf(ManyErrors.or(TwoErrors).check({ data: {} }));
  }

  test("limits nested errors independently for each option", () => {
    expect(manyErrors().formatError({ maxNestedErrors: 2 })).toBe([
      "object did not match any option in the schema. There were 2 options, and all options had errors. The errors for each option were:",
      "1. .data.one is missing",
      "   .data.two is missing",
      "   ... 8 more errors omitted for this option.",
      "2. .left is missing",
      "   .right is missing",
    ].join("\n"));
  });
```

Finally! No more massive impossible to read junk error messages!