### PR TITLE
Fix combinators

### DIFF
--- a/lib/as-kind.ts
+++ b/lib/as-kind.ts
@@ -1,8 +1,8 @@
 import type { TypedKind } from "./kind";
-import type { TypeImpl } from "./type";
+import type { Type } from "./type";
 
-export function asKind<T, U extends TypeImpl<T>>(type: U): U & TypedKind<T>;
-export function asKind<T>(type: TypeImpl<any>): TypedKind<T>;
-export function asKind<T>(type: TypeImpl<any>): TypedKind<T> {
+export function asKind<T, U extends Type<T>>(type: U): U & TypedKind<T>;
+export function asKind<T>(type: Type<any>): TypedKind<T>;
+export function asKind<T>(type: Type<any>): TypedKind<T> {
   return type as unknown as TypedKind<T>;
 }

--- a/lib/checks/array.ts
+++ b/lib/checks/array.ts
@@ -3,14 +3,14 @@ import { at } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
-import { Projection, TypeImpl } from "../type";
+import { Projection, Type } from "../type";
 
-export class Arr<T> extends TypeImpl<Array<T>> {
+export class Arr<T> extends Type<Array<T>> {
   readonly elementType: TypedKind<T>;
 
-  constructor(t: TypedKind<T>) {
+  constructor(t: Type<T>) {
     super();
-    this.elementType = t;
+    this.elementType = asKind(t);
   }
 
   check(val: any): Result<Array<T>> {
@@ -65,6 +65,6 @@ export class Arr<T> extends TypeImpl<Array<T>> {
   }
 }
 
-export function array<T>(t: TypedKind<T>): Arr<T> {
+export function array<T>(t: Type<T>): Arr<T> {
   return new Arr(t);
 }

--- a/lib/checks/map.ts
+++ b/lib/checks/map.ts
@@ -3,16 +3,16 @@ import { at } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
-import { Projection, TypeImpl } from "../type";
+import { Projection, Type } from "../type";
 
-export class MapType<K, V> extends TypeImpl<Map<K, V>> {
+export class MapType<K, V> extends Type<Map<K, V>> {
   readonly keyType: TypedKind<K>;
   readonly valueType: TypedKind<V>;
 
-  constructor(k: TypedKind<K>, v: TypedKind<V>) {
+  constructor(k: Type<K>, v: Type<V>) {
     super();
-    this.keyType = k;
-    this.valueType = v;
+    this.keyType = asKind(k);
+    this.valueType = asKind(v);
   }
 
   check(val: any): Result<Map<K, V>> {
@@ -80,6 +80,6 @@ export class MapType<K, V> extends TypeImpl<Map<K, V>> {
   }
 }
 
-export function map<K, V>(k: TypedKind<K>, v: TypedKind<V>): MapType<K, V> {
+export function map<K, V>(k: Type<K>, v: Type<V>): MapType<K, V> {
   return new MapType(k, v);
 }

--- a/lib/checks/primitives.ts
+++ b/lib/checks/primitives.ts
@@ -1,4 +1,4 @@
-import { TypedKind } from "../kind";
+import { Type } from "../type";
 import { typeOf } from "./type-of";
 import { value } from "./value";
 
@@ -12,6 +12,6 @@ export const undef = typeOf<undefined>('undefined');
 export const nil = value<null>(null);
 export const obj = typeOf<Object>('object');
 
-export function maybe<T>(check: TypedKind<T>) {
+export function maybe<T>(check: Type<T>) {
   return check.or(nil);
 }

--- a/lib/checks/set.ts
+++ b/lib/checks/set.ts
@@ -3,14 +3,14 @@ import { at } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
-import { Projection, TypeImpl } from "../type";
+import { Projection, Type } from "../type";
 
-export class SetType<V> extends TypeImpl<Set<V>> {
+export class SetType<V> extends Type<Set<V>> {
   readonly valueType: TypedKind<V>;
 
-  constructor(v: TypedKind<V>) {
+  constructor(v: Type<V>) {
     super();
-    this.valueType = v;
+    this.valueType = asKind(v);
   }
 
   check(val: any): Result<Set<V>> {
@@ -64,6 +64,6 @@ export class SetType<V> extends TypeImpl<Set<V>> {
   }
 }
 
-export function set<V>(v: TypedKind<V>): SetType<V> {
+export function set<V>(v: Type<V>): SetType<V> {
   return new SetType(v);
 }

--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -4,7 +4,7 @@ import type { Issue } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { Kind, TypedKind } from "../kind";
-import { Comment, Either, Intersection, Projection, Type, TypeImpl } from "../type";
+import { Comment, Either, Intersection, Projection, Type } from "../type";
 import { GetType } from "../get-type";
 import { undef } from "./primitives";
 
@@ -61,7 +61,7 @@ export type UnknownPropertiesIssue = {
   readonly subject: "object";
 };
 
-abstract class MergeableType<T> extends TypeImpl<T> {
+abstract class MergeableType<T> extends Type<T> {
   constructor(protected readonly objectShape: ObjectShape) {
     super();
   }
@@ -123,7 +123,7 @@ abstract class MergeableType<T> extends TypeImpl<T> {
   }
 
   /*
-   * TypeImpl.sliceResult checks first and projects afterward, which normally means reading object
+   * Type.sliceResult checks first and projects afterward, which normally means reading object
    * properties twice. A getter can return a different value on the second read, allowing slicing
    * to return a value that never passed validation. Validate and project each captured property
    * value together so the returned object contains exactly the values that were checked.
@@ -224,9 +224,9 @@ abstract class MergeableType<T> extends TypeImpl<T> {
 // Dicts and structs merge together in TypeScript, so we put both in the struct file
 export class Dict<V> extends MergeableType<RawDict<V>> {
   readonly valueType: TypedKind<V>;
-  constructor(v: TypedKind<V>, readonly namedKey: string = "key") {
-    super({ fields: emptyObjectFields(), exact: false, requirePlainObject: true, rest: v });
-    this.valueType = v;
+  constructor(v: Type<V>, readonly namedKey: string = "key") {
+    super({ fields: emptyObjectFields(), exact: false, requirePlainObject: true, rest: asKind(v) });
+    this.valueType = asKind(v);
   }
 
   keyName(key: string): Dict<V> {
@@ -275,11 +275,11 @@ function basicObjectErr<V>(val: any, requirePlainObject: boolean): Err<V> | unde
   return undefined;
 }
 
-export function dict<V>(v: TypedKind<V>): Dict<V> {
+export function dict<V>(v: Type<V>): Dict<V> {
   return new Dict(v);
 }
 
-export type FieldDef = Kind | MissingKey<any> | OptionalKey<any>;
+export type FieldDef = Type<any> | MissingKey<any> | OptionalKey<any>;
 
 export type TypeStruct = {
   [key: string]: FieldDef;
@@ -304,12 +304,12 @@ export type UnwrappedTypeStruct<T extends TypeStruct> =
   /* optional props */ Partial<Pick<UnwrapTypes<T>, OptionalPropertyNames<T>>>;
 
 export type TypeStructFor<T> = {
-  [K in keyof T]: TypedKind<T[K]>;
+  [K in keyof T]: Type<T[K]>;
 };
 
 export type StructFor<T> = Struct<TypeStructFor<T>>;
 
-export function keyType<T>(box: MissingKey<TypedKind<T>> | OptionalKey<TypedKind<T>> | TypedKind<T>): TypedKind<T> {
+export function keyType<T extends Type<any>>(box: MissingKey<T> | OptionalKey<T> | T): T {
   if(box instanceof MissingKey || box instanceof OptionalKey) {
     return box.type;
   }
@@ -331,8 +331,8 @@ function objectFields(definition: TypeStruct): ObjectShape["fields"] {
     const field = definition[prop];
     fields[prop] = {
       checker: field instanceof OptionalKey
-        ? undef.or(field.type)
-        : keyType(field),
+        ? asKind(undef.or(field.type))
+        : asKind(keyType(field)),
       allowsMissing: field instanceof MissingKey || field instanceof OptionalKey,
     };
   }
@@ -358,11 +358,11 @@ export function exact<T extends TypeStruct>(def: T): Struct<T> {
   return new Struct(def, true);
 }
 
-export function optional<T extends Kind>(check: T): OptionalKey<T> {
+export function optional<T extends Type<any>>(check: T): OptionalKey<T> {
   return new OptionalKey(check);
 }
 
-export function allowMissing<T extends Kind>(check: T): MissingKey<T> {
+export function allowMissing<T extends Type<any>>(check: T): MissingKey<T> {
   return new MissingKey(check);
 }
 
@@ -426,7 +426,7 @@ export function deepPartial<T extends TypeStruct>(ogstruct: Struct<T>): PartialS
       setOwn(partialDef, k, optional(v.type));
     }
     else {
-      setOwn(partialDef, k, deepPartialKind(v));
+      setOwn(partialDef, k, deepPartialKind(asKind(v)));
     }
   }
   const struct = new Struct(partialDef as DeepPartialTypeStruct<T>, ogstruct.exact);

--- a/lib/issue.ts
+++ b/lib/issue.ts
@@ -69,7 +69,7 @@ export function multiple(issues: ReadonlyArray<Issue>, subject: RuntimeType): Is
   return { kind: "multiple", subject, issues: flattened };
 }
 
-export function union(issues: ReadonlyArray<Issue>, subject: RuntimeType): UnionIssue {
+export function unionIssue(issues: ReadonlyArray<Issue>, subject: RuntimeType): UnionIssue {
   const flattened: Issue[] = [];
   for(const issue of issues) {
     if(issue.kind === "union") flattened.push(...issue.issues);

--- a/lib/kind.ts
+++ b/lib/kind.ts
@@ -1,4 +1,4 @@
-import type { Comment, Either, Intersection, TypeImpl, Validation } from "./type";
+import type { Comment, Either, Intersection, Type, Validation } from "./type";
 import type { TypeOf } from "./checks/type-of";
 import type { InstanceOf } from "./checks/instance-of";
 import type { Value } from "./checks/value";
@@ -29,4 +29,4 @@ export type Kind = Any
                  | PartialStruct<any>
                  ;
 
-export type TypedKind<T> = Kind & TypeImpl<T>;
+export type TypedKind<T> = Kind & Type<T>;

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -1,10 +1,10 @@
-import { TypedKind } from './kind'
+import { Type } from './type'
 
 class Case<In, Out> {
-  type: TypedKind<In>
+  type: Type<In>
   fn: (x: In) => Out
 
-  constructor(type: TypedKind<In>, fn: (x: In) => Out) {
+  constructor(type: Type<In>, fn: (x: In) => Out) {
     this.type = type
     this.fn = fn
   }
@@ -18,7 +18,7 @@ type OutOfCase<T extends Case<any, any>> = T extends Case<any, infer Out> ?
 
 export class CaseSwitch<Cases extends Case<any, any>> {
   cases: Cases[]
-  private memoAccept: TypedKind<InOfCase<Cases>> | undefined
+  private memoAccept: Type<InOfCase<Cases>> | undefined
 
   constructor(cases: Cases[]) {
     if (cases.length === 0) {
@@ -28,7 +28,7 @@ export class CaseSwitch<Cases extends Case<any, any>> {
   }
 
   // implemented lazily because not every CaseSwitch will be used
-  get accept(): TypedKind<InOfCase<Cases>> {
+  get accept(): Type<InOfCase<Cases>> {
     if (this.memoAccept) {
       return this.memoAccept
     }
@@ -55,7 +55,7 @@ export class CaseSwitch<Cases extends Case<any, any>> {
   /**
    * Create a new CaseSwitch that also handles the specified case.
    */
-  when<In, Out>(type: TypedKind<In>, fn: (v: In) => Out): CaseSwitch<Cases | Case<In, Out>> {
+  when<In, Out>(type: Type<In>, fn: (v: In) => Out): CaseSwitch<Cases | Case<In, Out>> {
     const c = new Case(type, fn)
     return new CaseSwitch([...this.cases, c])
   }
@@ -64,7 +64,7 @@ export class CaseSwitch<Cases extends Case<any, any>> {
 /**
  * Create a type switch that can be used with `match()`.
  */
-export function when<In, Out>(type: TypedKind<In>, fn: (v: In) => Out) {
+export function when<In, Out>(type: Type<In>, fn: (v: In) => Out) {
   const c = new Case(type, fn)
   return new CaseSwitch([c])
 }

--- a/lib/t.ts
+++ b/lib/t.ts
@@ -22,6 +22,7 @@ export * from "./format-issue";
 export * from "./issues/shared";
 export * from "./type";
 export * from "./get-type";
+export * from "./union";
 
 export * from "./checks/type-of";
 export * from "./checks/instance-of";

--- a/lib/to-jsonschema.ts
+++ b/lib/to-jsonschema.ts
@@ -1,4 +1,4 @@
-import { Type, Comment, Either, Intersection, Validation } from "./type";
+import { Comment, Either, Intersection, Validation } from "./type";
 import { TypeOf } from "./checks/type-of";
 import { InstanceOf } from "./checks/instance-of";
 import { Value } from "./checks/value";
@@ -94,7 +94,7 @@ export function toJSONSchema(title: string, type: Kind, opts?: Options): TopLeve
   return addMetadata(title, typeToSchema(type, options));
 }
 
-function typeToSchema(type: Type<any>, options: Required<Options>): JSONSchema {
+function typeToSchema(type: Kind, options: Required<Options>): JSONSchema {
   if(type instanceof Comment) {
     return {
       description: formatCommentString(type.commentStr),
@@ -128,7 +128,7 @@ function typeToSchema(type: Type<any>, options: Required<Options>): JSONSchema {
   return fromPartial(type, options);
 }
 
-function areSerializableValues(types: Array<Type<any>>): types is Array<Value<JSONValue>> {
+function areSerializableValues(types: Array<Kind>): types is Array<Value<JSONValue>> {
   for(const type of types) {
     if(!(type instanceof Value)) return false;
     if(!isSerializable(type.val)) return false;
@@ -372,8 +372,8 @@ function fromPartial(type: PartialStruct<any>, options: Required<Options>): JSON
 
 function flatTypes(
   klass: { new(...args: any): Either<any, any> },
-  node: Type<any>
-): Array<Type<any>> {
+  node: Kind
+): Array<Kind> {
   if(node instanceof klass) {
     return flatTypes(klass, node.l).concat(flatTypes(klass, node.r));
   }

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -13,7 +13,7 @@ import { Kind } from "./kind";
 
 type ToTypescriptOpts = {
   useReference?: {
-    [ref: string]: Type<any>,
+    [ref: string]: Kind,
   },
 
   indent: string,
@@ -58,7 +58,7 @@ export function toTypescript(...args: SingleConversion | SingleConversionWithOpt
   return output.join("\n\n");
 }
 
-function toTS(type: Type<any>, opts: ToTypescriptOpts): string {
+function toTS(type: Kind, opts: ToTypescriptOpts): string {
   if(opts.useReference) {
     for(const key in opts.useReference) {
       const val = opts.useReference[key];
@@ -144,7 +144,7 @@ function fromMergeIntersect(
   return renderIntersection(i.operands, opts);
 }
 
-function renderIntersection(operands: ReadonlyArray<Type<any>>, opts: ToTypescriptOpts) {
+function renderIntersection(operands: ReadonlyArray<Kind>, opts: ToTypescriptOpts) {
   const indentation = indent(opts);
   return [
     toTS(operands[0], opts),
@@ -249,10 +249,10 @@ function fromStruct(s: Struct<any>, opts: ToTypescriptOpts) {
 
 type StrippedComments = {
   comments: string[],
-  inner: Type<any>,
+  inner: Kind,
 };
 
-function stripOuterComments(t: Type<any> | OptionalKey<any>): StrippedComments {
+function stripOuterComments(t: Kind | OptionalKey<any>): StrippedComments {
   if(t instanceof OptionalKey) return stripOuterComments(t.type);
   if(t instanceof Comment) {
     const inner = stripOuterComments(t.wrapped);

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -1,5 +1,5 @@
 import { Err, Result } from "./result";
-import { union } from "./issue";
+import { unionIssue } from "./issue";
 import { RuntimeType, runtimeTypeOf } from "./issues/shared";
 import { asKind } from "./as-kind";
 import type { Kind, TypedKind } from "./kind";
@@ -11,14 +11,14 @@ export type Projection<T> =
 
 export type ProjectionKind = Projection<any>["kind"];
 
-export abstract class TypeImpl<T> {
+export abstract class Type<T> {
   abstract check(val: any): Result<T>;
   abstract sliceResult(val: any): Result<T>;
 
   protected abstract merge<R>(type: TypedKind<R>): TypedKind<T & R> | undefined;
   protected abstract project(val: any): Projection<T>;
 
-  protected projectionOf<R>(type: TypeImpl<R>, val: any): Projection<R> {
+  protected projectionOf<R>(type: Type<R>, val: any): Projection<R> {
     return type.project(val);
   }
 
@@ -61,16 +61,17 @@ export abstract class TypeImpl<T> {
    * -----------------------------------------------------------------------------------------------
    */
 
-  and<R>(r: TypedKind<R>): TypedKind<T&R> {
-    return intersect(asKind<T>(this), r, (l, r) => {
-      const left = l as TypeImpl<any>;
-      const right = r as TypeImpl<any>;
+  and<R>(r: Type<R>): TypedKind<T&R> {
+    const rightKind = asKind<R>(r);
+    return intersect(asKind<T>(this), rightKind, (l, r) => {
+      const left = l as Type<any>;
+      const right = r as Type<any>;
       return left.merge(r) || right.merge(l);
     });
   }
 
-  or<R>(r: TypedKind<R>): Either<T, R> {
-    return new Either(asKind<T>(this), r);
+  or<R>(r: Type<R>): Either<T, R> {
+    return new Either(asKind<T>(this), asKind<R>(r));
   }
 
   /*
@@ -91,9 +92,6 @@ export abstract class TypeImpl<T> {
     return new Comment(comment, asKind<T>(this));
   }
 }
-
-export const Type = TypeImpl;
-export type Type<T> = TypedKind<T>;
 
 type Merge = (l: Kind, r: Kind) => Kind | undefined;
 
@@ -147,7 +145,7 @@ function assert<T>(result: Result<T>): T {
  * class in order to extend it (since they themselves are Types).
  */
 
-export abstract class UnmergeableType<T> extends TypeImpl<T> {
+export abstract class UnmergeableType<T> extends Type<T> {
   sliceResult(val: any): Result<T> {
     const checked = this.check(val);
     if(checked instanceof Err) return checked;
@@ -180,9 +178,12 @@ export abstract class OpaqueType<T> extends UnmergeableType<T> {
  * A type that delegates to the given type, but adds a comment when converted to TypeScript
  */
 
-export class Comment<T> extends TypeImpl<T> {
-  constructor(readonly commentStr: string, readonly wrapped: TypedKind<T>) {
+export class Comment<T> extends Type<T> {
+  readonly wrapped: TypedKind<T>;
+
+  constructor(readonly commentStr: string, wrapped: Type<T>) {
     super();
+    this.wrapped = asKind(wrapped);
   }
 
   check(val: any): Result<T> {
@@ -265,14 +266,14 @@ export class Validation<T> extends ConstraintType<T> {
  * children are themselves doing key tracking.
  */
 
-export class Either<L, R> extends TypeImpl<L|R> {
+export class Either<L, R> extends Type<L|R> {
   readonly l: TypedKind<L>;
   readonly r: TypedKind<R>;
 
-  constructor(l: TypedKind<L>, r: TypedKind<R>) {
+  constructor(l: Type<L>, r: Type<R>) {
     super();
-    this.l = l;
-    this.r = r;
+    this.l = asKind(l);
+    this.r = asKind(r);
   }
 
   check(val: any): Result<L|R> {
@@ -280,7 +281,7 @@ export class Either<L, R> extends TypeImpl<L|R> {
     if(!(l instanceof Err)) return l;
     const r = this.r.check(val);
     if(!(r instanceof Err)) return r;
-    return new Err(union([ l.issue, r.issue ], runtimeTypeOf(val)));
+    return new Err(unionIssue([ l.issue, r.issue ], runtimeTypeOf(val)));
   }
 
   /*
@@ -292,7 +293,7 @@ export class Either<L, R> extends TypeImpl<L|R> {
     if(!(l instanceof Err)) return l;
     const r = this.r.sliceResult(val);
     if(!(r instanceof Err)) return r;
-    return new Err(union([ l.issue, r.issue ], runtimeTypeOf(val)));
+    return new Err(unionIssue([ l.issue, r.issue ], runtimeTypeOf(val)));
   }
 
   protected merge<Incoming>(type: TypedKind<Incoming>): TypedKind<(L|R) & Incoming> {
@@ -314,7 +315,7 @@ export class Either<L, R> extends TypeImpl<L|R> {
  * -------------------------------------------------------------------------------------------------
  */
 
-export class Intersection<T> extends TypeImpl<T> {
+export class Intersection<T> extends Type<T> {
   constructor(readonly operands: ReadonlyArray<Kind>) {
     super();
   }

--- a/lib/union.ts
+++ b/lib/union.ts
@@ -1,0 +1,25 @@
+import { never } from "./checks/never";
+import type { GetType } from "./get-type";
+import type { Type } from "./type";
+
+export function union<const Types extends ReadonlyArray<Type<any>>>(
+  ...types: Types
+): Type<GetType<Types[number]>>;
+export function union<const Types extends ReadonlyArray<Type<any>>>(
+  types: Types
+): Type<GetType<Types[number]>>;
+export function union(
+  ...args: Type<any>[] | [ ReadonlyArray<Type<any>> ]
+): Type<any> {
+  const types: ReadonlyArray<Type<any>> = args.length === 1 && Array.isArray(args[0])
+    ? args[0]
+    : args as Type<any>[];
+
+  if(types.length === 0) return never;
+
+  let result = types[0];
+  for(const type of types.slice(1)) {
+    result = result.or(type);
+  }
+  return result;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "tsc": "rm -rf build/ && tsc",
     "watch": "rm -rf build/ && tsc --watch",
     "test": "tsc --noEmit && vitest run --coverage",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm test && npm run tsc"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.10",

--- a/test/union.ts
+++ b/test/union.ts
@@ -1,0 +1,98 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as t from "../index";
+
+export function unionAll<T extends t.Type<any>>(array: readonly T[]): t.Type<t.GetType<T>> {
+  if(array.length === 1) return array[0];
+  return array[0].or(unionAll(array.slice(1)));
+}
+
+test("client-defined recursive union helpers compile and work", () => {
+  const type = unionAll([ t.str, t.num, t.bool ]);
+
+  expect(type.guard("hello")).toBe(true);
+  expect(type.guard(5)).toBe(true);
+  expect(type.guard(false)).toBe(true);
+  expect(type.guard(null)).toBe(false);
+});
+
+test("union accepts variadic types and preserves their union", () => {
+  const type = t.union(t.value("alpha"), t.value(1), t.value(true));
+
+  expectTypeOf(type).toEqualTypeOf<t.Type<"alpha" | 1 | true>>();
+  expect(type.guard("alpha")).toBe(true);
+  expect(type.guard(1)).toBe(true);
+  expect(type.guard(true)).toBe(true);
+  expect(type.guard("other")).toBe(false);
+});
+
+test("union accepts a readonly tuple and preserves its union", () => {
+  const types = [ t.value("alpha"), t.value(1), t.value(true) ] as const;
+  const type = t.union(types);
+
+  expectTypeOf(type).toEqualTypeOf<t.Type<"alpha" | 1 | true>>();
+  expect(type.guard("alpha")).toBe(true);
+  expect(type.guard(1)).toBe(true);
+  expect(type.guard(true)).toBe(true);
+});
+
+test("union accepts generic readonly arrays", () => {
+  function unionWithBuiltin<T extends t.Type<any>>(
+    array: readonly T[],
+  ): t.Type<t.GetType<T>> {
+    return t.union(array);
+  }
+
+  const type = unionWithBuiltin([ t.str, t.num, t.bool ]);
+  expect(type.guard("hello")).toBe(true);
+  expect(type.guard(5)).toBe(true);
+  expect(type.guard(false)).toBe(true);
+});
+
+test("union returns a single type unchanged", () => {
+  expect(t.union(t.str)).toBe(t.str);
+  expect(t.union([ t.str ] as const)).toBe(t.str);
+});
+
+test("an empty union is never", () => {
+  const variadic = t.union();
+  const tuple = t.union([] as const);
+
+  expectTypeOf(variadic).toEqualTypeOf<t.Type<never>>();
+  expectTypeOf(tuple).toEqualTypeOf<t.Type<never>>();
+  expect(variadic).toBe(t.never);
+  expect(tuple).toBe(t.never);
+  expect(variadic.guard("anything")).toBe(false);
+});
+
+test("generic Type values work with public combinators", () => {
+  function compose<T>(type: t.Type<T>) {
+    return {
+      array: t.array(type),
+      map: t.map(type, type),
+      set: t.set(type),
+      dict: t.dict(type),
+      maybe: t.maybe(type),
+      struct: t.subtype({
+        value: type,
+        optional: t.optional(type),
+        missing: t.allowMissing(type),
+      }),
+      either: type.or(type),
+      intersection: type.and(type),
+      comment: type.comment("generic"),
+      matcher: t.when(type, value => value),
+    };
+  }
+
+  const checks = compose(t.str);
+  expect(checks.array.guard([ "hello" ])).toBe(true);
+  expect(checks.map.guard(new Map([[ "key", "value" ]]))).toBe(true);
+  expect(checks.set.guard(new Set([ "value" ]))).toBe(true);
+  expect(checks.dict.guard({ key: "value" })).toBe(true);
+  expect(checks.maybe.guard(null)).toBe(true);
+  expect(checks.struct.guard({ value: "hello" })).toBe(true);
+  expect(checks.either.guard("hello")).toBe(true);
+  expect(checks.intersection.guard("hello")).toBe(true);
+  expect(checks.comment.guard("hello")).toBe(true);
+  expect(checks.matcher.run("hello")).toBe("hello");
+});


### PR DESCRIPTION
0.0.30 unintentionally changed the public contract for combinators from the normal Type to TypedKind. This fixes that, adds a test, and adds a default `union(...)` type that many Structural clients use which caught the bug.