### PR TITLE
Fix to-ts and to-jsonschema combinators

### DIFF
--- a/lib/to-jsonschema.ts
+++ b/lib/to-jsonschema.ts
@@ -1,4 +1,4 @@
-import { Comment, Either, Intersection, Validation } from "./type";
+import { Type, Comment, Either, Intersection, Validation } from "./type";
 import { TypeOf } from "./checks/type-of";
 import { InstanceOf } from "./checks/instance-of";
 import { Value } from "./checks/value";
@@ -85,13 +85,13 @@ const defaultOpts: Required<Options> = {
   errorOnNever: true,
 };
 
-export function toJSONSchema(title: string, type: Kind, opts?: Options): TopLevel<JSONSchema> {
+export function toJSONSchema(title: string, type: Type<any>, opts?: Options): TopLevel<JSONSchema> {
   const options = {
     ...defaultOpts,
     ...opts,
   };
 
-  return addMetadata(title, typeToSchema(type, options));
+  return addMetadata(title, typeToSchema(type as Kind, options));
 }
 
 function typeToSchema(type: Kind, options: Required<Options>): JSONSchema {

--- a/lib/to-ts.ts
+++ b/lib/to-ts.ts
@@ -13,7 +13,7 @@ import { Kind } from "./kind";
 
 type ToTypescriptOpts = {
   useReference?: {
-    [ref: string]: Kind,
+    [ref: string]: Type<any>,
   },
 
   indent: string,
@@ -24,9 +24,9 @@ export type TypescriptUserOpts = Partial<ToTypescriptOpts> & {
   assignToType?: string,
 };
 
-type SingleConversionWithOpts = [ type: Kind, userOpts: TypescriptUserOpts ];
-type SingleConversion = [ type: Kind ];
-type MultipleConversion = [ types: { [name: string]: Kind } ];
+type SingleConversionWithOpts = [ type: Type<any>, userOpts: TypescriptUserOpts ];
+type SingleConversion = [ type: Type<any> ];
+type MultipleConversion = [ types: { [name: string]: Type<any> } ];
 
 export function toTypescript(...args: SingleConversion | SingleConversionWithOpts | MultipleConversion): string {
   if(args.length === 2) {
@@ -35,7 +35,7 @@ export function toTypescript(...args: SingleConversion | SingleConversionWithOpt
     // assignToType is only valid at the top level, so delete it if it exists
     delete opts.assignToType;
 
-    const ts = toTS(type, opts);
+    const ts = toTS(type as Kind, opts);
 
     if(userOpts.assignToType) return `type ${userOpts.assignToType} = ${ts};`;
     return ts;

--- a/test/generic-conversion.ts
+++ b/test/generic-conversion.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { JSON_SCHEMA_VERSION, t, toJSONSchema, toTypescript } from "../index";
+
+type SchemaContainer<T> = {
+  schema: t.Type<T>;
+};
+
+function renderSchema<T>({ schema }: SchemaContainer<T>) {
+  return {
+    jsonSchema: toJSONSchema("Schema", schema),
+    typescript: toTypescript(schema),
+  };
+}
+
+test("converters accept schemas whose concrete kind was erased to Type", () => {
+  const rendered = renderSchema({
+    schema: t.subtype({
+      name: t.str,
+    }),
+  });
+
+  expect(rendered.typescript).toBe("{\n  name: string,\n}");
+  expect(rendered.jsonSchema).toEqual({
+    $schema: JSON_SCHEMA_VERSION,
+    title: "Schema",
+    type: "object",
+    required: [ "name" ],
+    properties: {
+      name: { type: "string" },
+    },
+  });
+});

--- a/test/kind.ts
+++ b/test/kind.ts
@@ -1,6 +1,28 @@
 import { expect, test } from "vitest";
 import * as t from "../index";
 
+function assertNever<_ extends never>(): void {}
+
+test("Kind includes every exported concrete Type class", () => {
+  assertNever<{
+    [K in Exclude<
+      keyof typeof t,
+      "Type" | "UnmergeableType" | "ConstraintType" | "OpaqueType"
+    >]: (typeof t)[K] extends abstract new(...args: any[]) => infer Instance
+      ? Instance extends t.Type<any>
+        ? Instance extends t.Kind
+          ? never
+          : Instance
+        : never
+      : never;
+  }[Exclude<
+    keyof typeof t,
+    "Type" | "UnmergeableType" | "ConstraintType" | "OpaqueType"
+  >]>();
+
+  expect(true).toBe(true);
+});
+
 test("allows type narrowing for exhaustiveness checking", () => {
   // Let's write a function that takes a validation, and see if we can use type narrowing with
   // successive `if` statements to get ourselves to be able to call this function on a `t.Kind`.


### PR DESCRIPTION
More type-level breakage to fix. `toTypeScript` and `toJSONSchema` would often cause compile errors they didn't previously cause due to type-level refactoring. This enforces at compile time that Kind covers all non-intermediate types, and widens the former functions to accept `Type` and cast to `Kind`.