### PR TITLE
Improve error messages for unknown keys

### DIFF
--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -55,9 +55,8 @@ export type MissingIssue = {
   readonly subject: "object";
 };
 
-export type UnknownPropertiesIssue = {
-  readonly kind: "unknown-properties";
-  readonly count: number;
+export type UnknownPropertyIssue = {
+  readonly kind: "unknown-property";
   readonly subject: "object";
 };
 
@@ -91,7 +90,6 @@ abstract class MergeableType<T> extends Type<T> {
 
     const valueKeys = this.objectShape.exact ? enumerableOwnKeys(val) : Object.keys(val);
     let dictionaryIndex = 0;
-    let unknownProperties = 0;
     for(const prop of valueKeys) {
       if(hasOwn(this.objectShape.fields, prop)) continue;
 
@@ -107,17 +105,14 @@ abstract class MergeableType<T> extends Type<T> {
         dictionaryIndex += 1;
       }
       else if(this.objectShape.exact) {
-        unknownProperties += 1;
+        issues.push(at(
+          { kind: "property", key: prop },
+          { kind: "unknown-property", subject: "object" },
+          "object",
+        ));
       }
     }
 
-    if(unknownProperties > 0) {
-      issues.push({
-        kind: "unknown-properties",
-        count: unknownProperties,
-        subject: "object",
-      });
-    }
     if(issues.length === 0) return val as T;
     return new Err(multiple(issues, "object"));
   }
@@ -155,7 +150,6 @@ abstract class MergeableType<T> extends Type<T> {
 
     const valueKeys = this.objectShape.exact ? enumerableOwnKeys(val) : Object.keys(val);
     let dictionaryIndex = 0;
-    let unknownProperties = 0;
     for(const prop of valueKeys) {
       if(hasOwn(this.objectShape.fields, prop)) continue;
 
@@ -172,17 +166,14 @@ abstract class MergeableType<T> extends Type<T> {
         dictionaryIndex += 1;
       }
       else if(this.objectShape.exact) {
-        unknownProperties += 1;
+        issues.push(at(
+          { kind: "property", key: prop },
+          { kind: "unknown-property", subject: "object" },
+          "object",
+        ));
       }
     }
 
-    if(unknownProperties > 0) {
-      issues.push({
-        kind: "unknown-properties",
-        count: unknownProperties,
-        subject: "object",
-      });
-    }
     if(issues.length === 0) return result as T;
     return new Err(multiple(issues, "object"));
   }
@@ -242,7 +233,7 @@ function ownKeys<T extends object>(value: T): Array<Extract<keyof T, string | sy
   return Reflect.ownKeys(value) as Array<Extract<keyof T, string | symbol>>;
 }
 
-function enumerableOwnKeys(value: object): PropertyKey[] {
+function enumerableOwnKeys(value: object): Array<string | symbol> {
   return Reflect.ownKeys(value).filter(key => {
     return Object.prototype.propertyIsEnumerable.call(value, key);
   });

--- a/lib/format-issue.ts
+++ b/lib/format-issue.ts
@@ -39,8 +39,8 @@ function format(
         : `${formatSubject(path, issue.subject)} failed validation ${quote(issue.description)}`;
     case "missing":
       return `${formatSubject(path, issue.subject)} is missing`;
-    case "unknown-properties":
-      return `${formatSubject(path, issue.subject)} has ${count(issue.count, "unknown property", "unknown properties")}`;
+    case "unknown-property":
+      return `${formatSubject(path, issue.subject)} is an unknown property`;
     case "never":
       return `${formatSubject(path, issue.subject)} cannot satisfy never`;
     case "at":

--- a/lib/issue.ts
+++ b/lib/issue.ts
@@ -1,7 +1,7 @@
 import type { InstanceOfIssue } from "./checks/instance-of";
 import type { GuardIssue } from "./checks/is";
 import type { NeverIssue } from "./checks/never";
-import type { MissingIssue, UnknownPropertiesIssue } from "./checks/struct";
+import type { MissingIssue, UnknownPropertyIssue } from "./checks/struct";
 import type { LiteralIssue } from "./checks/value";
 import type { RuntimeType, TypeMismatchIssue } from "./issues/shared";
 import type { ValidationIssue } from "./type";
@@ -13,7 +13,7 @@ export type LeafIssue =
   | GuardIssue
   | ValidationIssue
   | MissingIssue
-  | UnknownPropertiesIssue
+  | UnknownPropertyIssue
   | NeverIssue;
 
 export type PathSegment =

--- a/test/error.ts
+++ b/test/error.ts
@@ -146,9 +146,11 @@ describe("issue formatting", () => {
   });
 
   test("structures an unknown property as a path", () => {
-    const error = errorOf(t.exact({}).check({ poop: true }));
+    const type = t.exact({});
+    const error = errorOf(type.check({ poop: true }));
 
     expect(error.message).toBe(".poop is an unknown property");
+    expect(() => type.slice({ poop: true })).toThrow(".poop is an unknown property");
     expect(error.issue).toEqual({
       kind: "at",
       subject: "object",

--- a/test/error.ts
+++ b/test/error.ts
@@ -130,7 +130,7 @@ describe("issue formatting", () => {
     expect(error.message).toBe("<1st value in set>.id is not a number");
   });
 
-  test("does not render dictionary or unknown property names", () => {
+  test("anonymizes dictionary keys and renders exact-type unknown property names", () => {
     const dictionaryError = errorOf(t.subtype({
       settings: t.dict(t.num),
     }).check({ settings: { "private-key": "private" } }));
@@ -139,7 +139,25 @@ describe("issue formatting", () => {
     }).check({ profile: { "private-one": 1, "private-two": 2 } }));
 
     expect(dictionaryError.message).toBe(".settings.<1st value in dictionary> is not a number");
-    expect(exactError.message).toBe(".profile has 2 unknown properties");
+    expect(exactError.message).toBe([
+      ".profile[\"private-one\"] is an unknown property",
+      ".profile[\"private-two\"] is an unknown property",
+    ].join("\n"));
+  });
+
+  test("structures an unknown property as a path", () => {
+    const error = errorOf(t.exact({}).check({ poop: true }));
+
+    expect(error.message).toBe(".poop is an unknown property");
+    expect(error.issue).toEqual({
+      kind: "at",
+      subject: "object",
+      path: [ { kind: "property", key: "poop" } ],
+      issue: {
+        kind: "unknown-property",
+        subject: "object",
+      },
+    });
   });
 
   test("condenses simple union failures", () => {
@@ -487,9 +505,15 @@ describe("error privacy", () => {
     expectSecretAbsent(t.num.or(t.bool), secret);
   });
 
-  test("does not retain or render input-derived property names", () => {
+  test("does not retain or render dictionary property names", () => {
     expectSecretAbsent(t.dict(t.num), { [secret]: secret });
-    expectSecretAbsent(t.exact({}), { [secret]: true });
+  });
+
+  test("retains exact-type unknown property names for diagnostics", () => {
+    const error = errorOf(t.exact({}).check({ [secret]: true }));
+
+    expect(error.message).toContain(secret);
+    expect(JSON.stringify(error.issue)).toContain(secret);
   });
 
   test("does not retain or render exceptions thrown by callbacks", () => {


### PR DESCRIPTION
Our improved error messaging was a bit *too* privacy sensitive, and the `.exact` type hid the name of the key that was unknown if you passed in an unknown key. This is basically unusable, so we instead show it.