### PR TITLE
Perf improvements

### DIFF
--- a/lib/checks/array.ts
+++ b/lib/checks/array.ts
@@ -3,9 +3,9 @@ import { at } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
-import { Projection, Type } from "../type";
+import { Projection, Type, TypeImpl } from "../type";
 
-export class Arr<T> extends Type<Array<T>> {
+export class Arr<T> extends TypeImpl<Array<T>> {
   readonly elementType: TypedKind<T>;
 
   constructor(t: Type<T>) {

--- a/lib/checks/map.ts
+++ b/lib/checks/map.ts
@@ -3,9 +3,9 @@ import { at } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
-import { Projection, Type } from "../type";
+import { Projection, Type, TypeImpl } from "../type";
 
-export class MapType<K, V> extends Type<Map<K, V>> {
+export class MapType<K, V> extends TypeImpl<Map<K, V>> {
   readonly keyType: TypedKind<K>;
   readonly valueType: TypedKind<V>;
 

--- a/lib/checks/set.ts
+++ b/lib/checks/set.ts
@@ -3,9 +3,9 @@ import { at } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { TypedKind } from "../kind";
-import { Projection, Type } from "../type";
+import { Projection, Type, TypeImpl } from "../type";
 
-export class SetType<V> extends Type<Set<V>> {
+export class SetType<V> extends TypeImpl<Set<V>> {
   readonly valueType: TypedKind<V>;
 
   constructor(v: Type<V>) {

--- a/lib/checks/struct.ts
+++ b/lib/checks/struct.ts
@@ -4,7 +4,7 @@ import type { Issue } from "../issue";
 import { typeMismatch } from "../issues/shared";
 import { asKind } from "../as-kind";
 import { Kind, TypedKind } from "../kind";
-import { Comment, Either, Intersection, Projection, Type } from "../type";
+import { Comment, Either, Intersection, Projection, Type, TypeImpl } from "../type";
 import { GetType } from "../get-type";
 import { undef } from "./primitives";
 
@@ -60,8 +60,8 @@ export type UnknownPropertyIssue = {
   readonly subject: "object";
 };
 
-abstract class MergeableType<T> extends Type<T> {
-  constructor(protected readonly objectShape: ObjectShape) {
+abstract class MergeableType<T> extends TypeImpl<T> {
+  constructor(private readonly objectShape: ObjectShape) {
     super();
   }
 

--- a/lib/get-type.ts
+++ b/lib/get-type.ts
@@ -1,7 +1,3 @@
 import { Type } from "./type";
 
-type GenericFn<T, R extends Type<T>> = (...a: any[]) => R;
-
-export type GetType<T extends Type<any>> = T extends Type<infer U> ? U :
-                         (T extends GenericFn<any, infer R> ?
-                           (R extends Type<infer U> ? U : never) : never);
+export type GetType<T extends Type<any>> = T["_type"];

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -2,7 +2,6 @@ import { Err, Result } from "./result";
 import { unionIssue } from "./issue";
 import { RuntimeType, runtimeTypeOf } from "./issues/shared";
 import { asKind } from "./as-kind";
-import type { GetType } from "./get-type";
 import type { Kind, TypedKind } from "./kind";
 
 export type Projection<T> =
@@ -13,15 +12,10 @@ export type Projection<T> =
 export type ProjectionKind = Projection<any>["kind"];
 
 export abstract class Type<T> {
+  declare readonly _type: T;
+
   abstract check(val: any): Result<T>;
   abstract sliceResult(val: any): Result<T>;
-
-  protected abstract merge<R>(type: TypedKind<R>): TypedKind<T & R> | undefined;
-  protected abstract project(val: any): Projection<T>;
-
-  protected projectionOf<R>(type: Type<R>, val: any): Projection<R> {
-    return type.project(val);
-  }
 
   assert(val: any): T {
     return assert(this.check(val));
@@ -62,17 +56,15 @@ export abstract class Type<T> {
    * -----------------------------------------------------------------------------------------------
    */
 
-  and<R extends Type<any>>(r: R): Type<T & GetType<R>> {
-    const rightKind = asKind<GetType<R>>(r);
-    return intersect(asKind<T>(this), rightKind, (l, r) => {
-      const left = l as Type<any>;
-      const right = r as Type<any>;
-      return left.merge(r) || right.merge(l);
-    });
+  and<R>(r: Type<R>): Type<T & R> {
+    return new Intersection<T & R>([
+      asKind<T>(this),
+      asKind<R>(r),
+    ]);
   }
 
-  or<R extends Type<any>>(r: R): Either<T, GetType<R>> {
-    return new Either(asKind<T>(this), asKind<GetType<R>>(r));
+  or<R>(r: Type<R>): Either<T, R> {
+    return new Either(asKind<T>(this), asKind<R>(r));
   }
 
   /*
@@ -91,6 +83,24 @@ export abstract class Type<T> {
 
   comment(comment: string): Comment<T> {
     return new Comment(comment, asKind<T>(this));
+  }
+}
+
+export abstract class TypeImpl<T> extends Type<T> {
+  protected abstract merge<R>(type: TypedKind<R>): TypedKind<T & R> | undefined;
+  protected abstract project(val: any): Projection<T>;
+
+  protected projectionOf<R>(type: TypeImpl<R>, val: any): Projection<R> {
+    return type.project(val);
+  }
+
+  and<R>(r: Type<R>): Type<T & R> {
+    const rightKind = asKind<R>(r);
+    return intersect(asKind<T>(this), rightKind, (l, r) => {
+      const left = l as TypeImpl<any>;
+      const right = r as TypeImpl<any>;
+      return left.merge(r) || right.merge(l);
+    });
   }
 }
 
@@ -146,7 +156,7 @@ function assert<T>(result: Result<T>): T {
  * class in order to extend it (since they themselves are Types).
  */
 
-export abstract class UnmergeableType<T> extends Type<T> {
+export abstract class UnmergeableType<T> extends TypeImpl<T> {
   sliceResult(val: any): Result<T> {
     const checked = this.check(val);
     if(checked instanceof Err) return checked;
@@ -179,7 +189,7 @@ export abstract class OpaqueType<T> extends UnmergeableType<T> {
  * A type that delegates to the given type, but adds a comment when converted to TypeScript
  */
 
-export class Comment<T> extends Type<T> {
+export class Comment<T> extends TypeImpl<T> {
   readonly wrapped: TypedKind<T>;
 
   constructor(readonly commentStr: string, wrapped: Type<T>) {
@@ -267,7 +277,7 @@ export class Validation<T> extends ConstraintType<T> {
  * children are themselves doing key tracking.
  */
 
-export class Either<L, R> extends Type<L|R> {
+export class Either<L, R> extends TypeImpl<L|R> {
   readonly l: TypedKind<L>;
   readonly r: TypedKind<R>;
 
@@ -316,7 +326,7 @@ export class Either<L, R> extends Type<L|R> {
  * -------------------------------------------------------------------------------------------------
  */
 
-export class Intersection<T> extends Type<T> {
+export class Intersection<T> extends TypeImpl<T> {
   constructor(readonly operands: ReadonlyArray<Kind>) {
     super();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "structural",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "structural",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "structural",
   "author": "Matt Baker <@reissbaker>",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Runtime structural typechecker",
   "repository": {
     "type": "git",

--- a/test/kind.ts
+++ b/test/kind.ts
@@ -7,7 +7,7 @@ test("Kind includes every exported concrete Type class", () => {
   assertNever<{
     [K in Exclude<
       keyof typeof t,
-      "Type" | "UnmergeableType" | "ConstraintType" | "OpaqueType"
+      "Type" | "TypeImpl" | "UnmergeableType" | "ConstraintType" | "OpaqueType"
     >]: (typeof t)[K] extends abstract new(...args: any[]) => infer Instance
       ? Instance extends t.Type<any>
         ? Instance extends t.Kind
@@ -17,7 +17,7 @@ test("Kind includes every exported concrete Type class", () => {
       : never;
   }[Exclude<
     keyof typeof t,
-    "Type" | "UnmergeableType" | "ConstraintType" | "OpaqueType"
+    "Type" | "TypeImpl" | "UnmergeableType" | "ConstraintType" | "OpaqueType"
   >]>();
 
   expect(true).toBe(true);


### PR DESCRIPTION
The post-0.0.29 versions were much slower at typecheck time than previously. This improves tsc perf without changing semantics.